### PR TITLE
Release 2 & 3: Expose approver_emails and category_ids in projects post and bulk post request payload

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -308,9 +308,16 @@ components:
           maxItems: 2
           nullable: false
           items:
-            allOf:
-              - $ref: '#/components/schemas/email'
+            type: string
+            maxLength: 127
             nullable: true
+            example: john.doe@example.com
+            description: >
+              An immutable field that represents the email address of the
+              employee.
+
+              Must be compliant with <a
+              href='https://www.ietf.org/rfc/rfc822.txt'>RFC 822.</a>
           example:
             - approver1@example.com
             - approver2@example.com

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -10043,7 +10043,7 @@ paths:
                         type: string
                         nullable: true
                       data:
-                        type: string
+                        type: object
                         nullable: true
         '401':
           description: Unauthorised request

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -309,6 +309,7 @@ components:
           nullable: false
           items:
             $ref: '#/components/schemas/email'
+            nullable: true
           example:
             - approver1@example.com
             - approver2@example.com

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -293,7 +293,52 @@ components:
         restricted_spender_user_ids:
           $ref: '#/components/schemas/restricted_spender_user_ids'
         approver_user_ids:
-          $ref: '#/components/schemas/approver_user_ids'
+          allOf:
+            - $ref: '#/components/schemas/approver_user_ids'
+          description: >
+            - List of IDs of users who are approvers of the project.
+
+            - Either `approver_user_ids` or `approver_emails` can be used but
+            not both.
+
+            - The default value for approver_user_ids is `[]` and it is
+            applicable only when creating the project.
+        approver_emails:
+          type: array
+          maxItems: 2
+          nullable: false
+          items:
+            $ref: '#/components/schemas/email'
+          example:
+            - approver1@example.com
+            - approver2@example.com
+          description: >
+            - List of emails of employees that are approvers for the project.
+
+            - Either `approver_user_ids` or `approver_emails` can be used but
+            not both.
+
+            - The default value for approver_emails is `[]` and it is applicable
+            only when creating the project.
+        category_ids:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/id_integer'
+          example:
+            - 87291
+            - 78322
+            - 492
+          description: >
+            - List of IDs of categories which can be used with the project.
+
+            - `null` value indicates that all categories in the org are
+            applicable for the project.
+
+            - `[]` value indicates that no category in the org is applicable for
+            the project.
+
+            - The default value of `category_ids` is `null`
     bulk_error:
       type: object
       properties:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -308,7 +308,8 @@ components:
           maxItems: 2
           nullable: false
           items:
-            $ref: '#/components/schemas/email'
+            allOf:
+              - $ref: '#/components/schemas/email'
             nullable: true
           example:
             - approver1@example.com

--- a/src/admin/paths/admin@projects@bulk.yaml
+++ b/src/admin/paths/admin@projects@bulk.yaml
@@ -18,7 +18,7 @@ post:
             data:
               type: array
               items:
-                $ref: "../../components/schemas/project.yaml#/project_in"
+                $ref: ../../components/schemas/project.yaml#/project_in
   responses:
     '200':
       description: OK
@@ -28,7 +28,7 @@ post:
         application/json:
           schema:
             oneOf: 
-              - $ref: '../../components/schemas/bulk_error.yaml'
+              - $ref: ../../components/schemas/bulk_error.yaml
               - type: object
                 properties:
                   error:
@@ -38,19 +38,19 @@ post:
                     type: string
                     nullable: true
                   data:
-                    type: string
+                    type: object
                     nullable: true
     '401':
       description: Unauthorised request
       content:
         application/json:
           schema:
-            $ref: '../../components/schemas/401.yaml'
+            $ref: ../../components/schemas/401.yaml
     '403':
       description: Forbidden
       content:
         application/json:
           schema:
-            $ref: "../../components/schemas/403.yaml"
+            $ref: ../../components/schemas/403.yaml
 
               

--- a/src/components/schemas/project.yaml
+++ b/src/components/schemas/project.yaml
@@ -110,7 +110,8 @@ project_in:
       maxItems: 2
       nullable: False
       items:
-        $ref: './fields.yaml#/email'
+        allOf:
+          - $ref: './fields.yaml#/email'
         nullable: True
       example: [ 'approver1@example.com', 'approver2@example.com' ]
       description: |

--- a/src/components/schemas/project.yaml
+++ b/src/components/schemas/project.yaml
@@ -110,9 +110,16 @@ project_in:
       maxItems: 2
       nullable: False
       items:
-        allOf:
-          - $ref: './fields.yaml#/email'
+        type: string
+        # format: email
+        maxLength: 127
         nullable: True
+        example: john.doe@example.com
+        description: >
+          An immutable field that represents the email address of the employee.
+
+          Must be compliant with <a href='https://www.ietf.org/rfc/rfc822.txt'>RFC
+          822.</a>
       example: [ 'approver1@example.com', 'approver2@example.com' ]
       description: |
         - List of emails of employees that are approvers for the project.

--- a/src/components/schemas/project.yaml
+++ b/src/components/schemas/project.yaml
@@ -111,6 +111,7 @@ project_in:
       nullable: False
       items:
         $ref: './fields.yaml#/email'
+        nullable: True
       example: [ 'approver1@example.com', 'approver2@example.com' ]
       description: |
         - List of emails of employees that are approvers for the project.

--- a/src/components/schemas/project.yaml
+++ b/src/components/schemas/project.yaml
@@ -99,7 +99,34 @@ project_in:
     restricted_spender_user_ids:
       $ref: './fields.yaml#/restricted_spender_user_ids'
     approver_user_ids:
-      $ref: './fields.yaml#/approver_user_ids'
+      allOf:
+        - $ref: './fields.yaml#/approver_user_ids'
+      description: |
+        - List of IDs of users who are approvers of the project.
+        - Either `approver_user_ids` or `approver_emails` can be used but not both.
+        - The default value for approver_user_ids is `[]` and it is applicable only when creating the project.
+    approver_emails:
+      type: array
+      maxItems: 2
+      nullable: False
+      items:
+        $ref: './fields.yaml#/email'
+      example: [ 'approver1@example.com', 'approver2@example.com' ]
+      description: |
+        - List of emails of employees that are approvers for the project.
+        - Either `approver_user_ids` or `approver_emails` can be used but not both.
+        - The default value for approver_emails is `[]` and it is applicable only when creating the project.
+    category_ids:
+      type: array
+      nullable: True
+      items:
+        $ref: './fields.yaml#/id_integer'
+      example: [ 87291, 78322, 492 ]
+      description: |
+        - List of IDs of categories which can be used with the project.
+        - `null` value indicates that all categories in the org are applicable for the project.
+        - `[]` value indicates that no category in the org is applicable for the project.
+        - The default value of `category_ids` is `null`
 
 admin_approver_project_out:
   type: object


### PR DESCRIPTION
## Description

Expose `category_ids` and `approver_emails` key in platform POST and bulk POST projects API.

Clickup link: https://app.clickup.com/t/85zrhfv01
