### PR TITLE
Add more info for restricted_spender_user_ids key in projects API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can check the version by running
 
 ## To preview changes ##
 
-    openapi preview-docs src/spender/openapi.yaml
+    openapi preview-docs src/admin/openapi.yaml
 
 ## Mock Server ##
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can check the version by running
 
 ## To preview changes ##
 
-    openapi preview-docs src/admin/openapi.yaml
+    openapi preview-docs src/spender/openapi.yaml
 
 ## Mock Server ##
 

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -311,6 +311,11 @@ components:
 
             - `[]` value indicates that no users in the org can access this
             object.
+
+            - **Note:**
+              - **_When the `restrict employee to their own projects` feature is disabled, only `null` value is accepted._**
+              - _If the `restrict employee to their own projects` feature is **disabled**, then the default value while creating project  is `null`._
+              - _If the `restrict employee to their own projects` feature is **enabled**, then the default value while creating project is `[]`._
         approver_user_ids:
           allOf:
             - $ref: '#/components/schemas/approver_user_ids'

--- a/src/components/schemas/project.yaml
+++ b/src/components/schemas/project.yaml
@@ -97,7 +97,20 @@ project_in:
     is_enabled:
       $ref: ./fields.yaml#/is_enabled
     restricted_spender_user_ids:
-      $ref: './fields.yaml#/restricted_spender_user_ids'
+      type: array
+      nullable: True
+      items:
+        type: string
+        nullable: False
+        maxLength: 15
+        description: |
+          This id is provided by Fyle to identify an object.
+        example: 'uswoirwlwwg'
+      example: [ 'uswoirwlwwg', 'uswlgwkgw42' ]
+      description: |
+        - List of IDs of users who can access this object.
+        - `null` value indicates that all users in the org can access this object.
+        - `[]` value indicates that no users in the org can access this object.
     approver_user_ids:
       allOf:
         - $ref: './fields.yaml#/approver_user_ids'

--- a/src/components/schemas/project.yaml
+++ b/src/components/schemas/project.yaml
@@ -111,6 +111,10 @@ project_in:
         - List of IDs of users who can access this object.
         - `null` value indicates that all users in the org can access this object.
         - `[]` value indicates that no users in the org can access this object.
+        - **Note:**
+          - **_When the `restrict employee to their own projects` feature is disabled, only `null` value is accepted._**
+          - _If the `restrict employee to their own projects` feature is **disabled**, then the default value while creating project  is `null`._
+          - _If the `restrict employee to their own projects` feature is **enabled**, then the default value while creating project is `[]`._
     approver_user_ids:
       allOf:
         - $ref: './fields.yaml#/approver_user_ids'


### PR DESCRIPTION
Add more info for restricted_spender_user_ids key in projects API.

Before:
<img width="1440" alt="Screenshot 2023-01-19 at 2 14 35 PM" src="https://user-images.githubusercontent.com/22430409/213448526-f992bd38-d0ec-45bf-be4d-774ee3617334.png">

After:
<img width="1440" alt="Screenshot 2023-01-19 at 6 25 32 PM" src="https://user-images.githubusercontent.com/22430409/213448449-725687f1-62f0-433c-803a-53e170cf3a40.png">
