### PR TITLE
fix: Add is_enabled key as optional + Add info that name and sub category cannot be same

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can check the version by running
 
 ## To preview changes ##
 
-    openapi preview-docs src/spender/openapi.yaml
+    openapi preview-docs src/admin/openapi.yaml
 
 ## Mock Server ##
 

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -493,7 +493,6 @@ components:
       type: object
       required:
         - name
-        - is_enabled
       additionalProperties: false
       properties:
         id:
@@ -508,7 +507,7 @@ components:
           type: string
           maxLength: 255
           example: Turbo charged
-          description: Represents the name of the sub_category.
+          description: Represents the sub category of the category. Note that the name and sub category cannot be same.
         is_enabled:
           $ref: '#/components/schemas/is_enabled'
         system_category:

--- a/src/components/schemas/category.yaml
+++ b/src/components/schemas/category.yaml
@@ -87,7 +87,6 @@ category_in:
   type: object
   required:
     - name
-    - is_enabled
   additionalProperties: False
   properties:
     id:
@@ -102,7 +101,7 @@ category_in:
       type: string
       maxLength: 255
       example: Turbo charged
-      description: Represents the name of the sub_category.
+      description: Represents the sub category of the category. Note that the name and sub category cannot be same.
     is_enabled:
       $ref: ./fields.yaml#/is_enabled
     system_category:


### PR DESCRIPTION
Description:
Add is_enabled key as optional + Add info that name and sub category cannot be same

Clickup: https://app.clickup.com/t/85zrnr59e

Old:
POST /admin/categories
<img width="1440" alt="Screenshot 2023-03-02 at 6 16 15 PM" src="https://user-images.githubusercontent.com/22430409/222433380-1f3a9251-5031-41fa-bffe-9ca902b539cd.png">

POST /admin/categories/bulk
<img width="1440" alt="Screenshot 2023-03-02 at 6 16 05 PM" src="https://user-images.githubusercontent.com/22430409/222433563-40616782-b77d-4580-9eaa-22cd0a47c1e4.png">

New:
POST /admin/categories
<img width="1440" alt="Screenshot 2023-03-02 at 6 15 09 PM" src="https://user-images.githubusercontent.com/22430409/222433617-d907a1dd-3ea9-4259-ad29-60f4cf835fc6.png">

POST /admin/categories/bulk
<img width="1440" alt="Screenshot 2023-03-02 at 6 15 26 PM" src="https://user-images.githubusercontent.com/22430409/222433711-07b04abd-d53e-43ab-84c4-91f833c821d6.png">
