### PR TITLE
fix: Updated admin mileage rate API doc to reflect required payload

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -1235,6 +1235,11 @@ components:
           $ref: '#/components/schemas/code'
     mileage_rate_in:
       type: object
+      required:
+        - unit
+        - rate
+        - vehicle_type
+        - is_enabled
       properties:
         id:
           $ref: '#/components/schemas/id_integer'
@@ -1255,6 +1260,9 @@ components:
           type: array
           items:
             type: object
+            required:
+              - rate
+              - limit
             properties:
               rate:
                 type: number

--- a/src/components/schemas/mileage_rate.yaml
+++ b/src/components/schemas/mileage_rate.yaml
@@ -58,6 +58,11 @@ mileage_rate_out_embed:
 
 mileage_rate_in:
   type: object
+  required:
+    - unit
+    - rate
+    - vehicle_type
+    - is_enabled
   properties:
     id:
       $ref: './fields.yaml#/id_integer'
@@ -82,6 +87,9 @@ mileage_rate_in:
       type: array
       items:
         type: object
+        required:
+          - rate
+          - limit
         properties:
           rate:
             type: number


### PR DESCRIPTION
ClickUp - https://app.clickup.com/t/85zrthjfm

- Currently the admin mileage rates POST API doc doesn't reflect the `required` fields needed in the payload.
- Added `required` in the fields that are mandatory for the API.

### Updated Doc screenshot
![Screenshot 2023-03-22 at 4 59 12 PM](https://user-images.githubusercontent.com/21246960/226891026-4951a6c4-9394-476f-936d-2e636fbb75ec.png)
