### PR TITLE
feat: Add new keys in `POST admin/employees/invite/bulk`

### DIFF
--- a/admin.yaml
+++ b/admin.yaml
@@ -1701,7 +1701,7 @@ components:
           $ref: '#/components/schemas/custom_fields'
         approver_emails:
           type: array
-          maxLength: 3
+          maxItems: 3
           nullable: true
           items:
             $ref: '#/components/schemas/email'

--- a/admin.yaml
+++ b/admin.yaml
@@ -1776,6 +1776,19 @@ components:
             $ref: '#/components/schemas/phone_number'
           description: |
             Mobile number of the employee
+        locale:
+          $ref: '#/components/schemas/locale'
+        mileage_settings:
+          $ref: '#/components/schemas/mileage_settings'
+        delegatee_emails:
+          type: array
+          maxItems: 1
+          nullable: False
+          items:
+            $ref: '#/components/schemas/email'
+          example: [ 'delegatee@example.com' ]
+          description: |
+            List of emails of employees that are delegatees for this employee.
     file_in:
       type: object
       required:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -1987,7 +1987,7 @@ components:
         delegatee_emails:
           type: array
           maxItems: 1
-          nullable: true
+          nullable: false
           items:
             $ref: '#/components/schemas/email'
           example:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -1563,6 +1563,57 @@ components:
       description: |
         phone number is represented by +CC MMMMMM... where CC is the country code, and is one to three digits, and MMMMMM... is the area code (where applicable) and subscriber number Max 12 digits
       pattern: /^(\+\d{1,3}[- ]?)?\d{10}$/
+    locale:
+      type: object
+      nullable: true
+      additionalProperties: false
+      properties:
+        abbreviation:
+          type: string
+          nullable: false
+          maxLength: 4
+          example: IST
+          description: |
+            Represents the abbreviation of the employee's locale.
+        offset:
+          type: string
+          nullable: false
+          maxLength: 9
+          example: '05:30:00'
+          description: |
+            Represents the offset of the employee's timezone from UTC.
+        timezone:
+          type: string
+          nullable: false
+          maxLength: 19
+          example: Asia/Kolkata
+          description: |
+            Represents the timezone of the employee.
+      description: |
+        Location and timezone settings of the employee.
+    mileage_settings:
+      type: object
+      nullable: true
+      additionalProperties: false
+      properties:
+        mileage_rate_labels:
+          type: array
+          nullable: true
+          items:
+            type: string
+            example: four_wheeler
+          example:
+            - four_wheeler
+            - two_wheeler
+        annual_mileage_of_user_before_joining_fyle:
+          type: object
+          nullable: true
+          items:
+            type: object
+          example:
+            two_wheeler: 44
+      description: |
+        Mileage settings of the employee.
     user_id:
       type: string
       description: |
@@ -1766,56 +1817,9 @@ components:
           description: |
             Mobile number of the employee
         locale:
-          type: object
-          nullable: true
-          additionalProperties: false
-          properties:
-            abbreviation:
-              type: string
-              nullable: false
-              maxLength: 4
-              example: IST
-              description: |
-                Represents the abbreviation of the employee's locale.
-            offset:
-              type: string
-              nullable: false
-              maxLength: 9
-              example: '05:30:00'
-              description: |
-                Represents the offset of the employee's timezone from UTC.
-            timezone:
-              type: string
-              nullable: false
-              maxLength: 19
-              example: Asia/Kolkata
-              description: |
-                Represents the timezone of the employee.
-          description: |
-            Location and timezone settings of the employee.
+          $ref: '#/components/schemas/locale'
         mileage_settings:
-          type: object
-          nullable: true
-          additionalProperties: false
-          properties:
-            mileage_rate_labels:
-              type: array
-              nullable: true
-              items:
-                type: string
-                example: four_wheeler
-              example:
-                - four_wheeler
-                - two_wheeler
-            annual_mileage_of_user_before_joining_fyle:
-              type: object
-              nullable: true
-              items:
-                type: object
-              example:
-                two_wheeler: 44
-          description: |
-            Mileage settings of the employee.
+          $ref: '#/components/schemas/mileage_settings'
         ach_account:
           type: object
           nullable: true
@@ -1906,7 +1910,7 @@ components:
           $ref: '#/components/schemas/custom_fields'
         approver_emails:
           type: array
-          maxLength: 3
+          maxItems: 3
           nullable: true
           items:
             $ref: '#/components/schemas/email'
@@ -1976,6 +1980,20 @@ components:
             $ref: '#/components/schemas/phone_number'
           description: |
             Mobile number of the employee
+        locale:
+          $ref: '#/components/schemas/locale'
+        mileage_settings:
+          $ref: '#/components/schemas/mileage_settings'
+        delegatee_emails:
+          type: array
+          maxItems: 1
+          nullable: true
+          items:
+            $ref: '#/components/schemas/email'
+          example:
+            - delegatee@example.com
+          description: |
+            List of emails of employees that are delegatees for this employee.
     employees_upload_out:
       type: object
       additionalProperties: false

--- a/src/components/schemas/employee.yaml
+++ b/src/components/schemas/employee.yaml
@@ -173,54 +173,9 @@ employee_out:
       description: |
         Mobile number of the employee
     locale:
-      type: object
-      nullable: True
-      additionalProperties: False
-      properties:
-        abbreviation:
-          type: string
-          nullable: False
-          maxLength: 4
-          example: 'IST'
-          description: >
-            Represents the abbreviation of the employee's locale.
-        offset:
-          type: string
-          nullable: False
-          maxLength: 9
-          example: '05:30:00'
-          description: >
-            Represents the offset of the employee's timezone from UTC.
-        timezone:
-          type: string
-          nullable: False
-          maxLength: 19
-          example: 'Asia/Kolkata'
-          description: >
-            Represents the timezone of the employee.
-      description: |
-        Location and timezone settings of the employee.
+      $ref: './fields.yaml#/locale'
     mileage_settings:
-      type: object
-      nullable: True
-      additionalProperties: False
-      properties:
-        mileage_rate_labels:
-          type: array
-          nullable: True
-          items:
-            type: string
-            example: 'four_wheeler'
-          example: ['four_wheeler', 'two_wheeler']
-        annual_mileage_of_user_before_joining_fyle:
-          type: object
-          nullable: True
-          items:
-            type: object
-          example:
-            "two_wheeler": 44
-      description: |
-        Mileage settings of the employee.
+      $ref: './fields.yaml#/mileage_settings'
     ach_account:
       type: object
       nullable: True

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -1251,3 +1251,54 @@ delegatees:
       description: |
         Date and time till which the delegation is active. If null, delegation is active indefinitely.
       nullable: True
+
+locale:
+  type: object
+  nullable: True
+  additionalProperties: False
+  properties:
+    abbreviation:
+      type: string
+      nullable: False
+      maxLength: 4
+      example: 'IST'
+      description: >
+        Represents the abbreviation of the employee's locale.
+    offset:
+      type: string
+      nullable: False
+      maxLength: 9
+      example: '05:30:00'
+      description: >
+        Represents the offset of the employee's timezone from UTC.
+    timezone:
+      type: string
+      nullable: False
+      maxLength: 19
+      example: 'Asia/Kolkata'
+      description: >
+        Represents the timezone of the employee.
+  description: |
+    Location and timezone settings of the employee.
+
+mileage_settings:
+  type: object
+  nullable: True
+  additionalProperties: False
+  properties:
+    mileage_rate_labels:
+      type: array
+      nullable: True
+      items:
+        type: string
+        example: 'four_wheeler'
+      example: ['four_wheeler', 'two_wheeler']
+    annual_mileage_of_user_before_joining_fyle:
+      type: object
+      nullable: True
+      items:
+        type: object
+      example:
+        "two_wheeler": 44
+  description: |
+    Mileage settings of the employee.

--- a/src/components/schemas/invitation.yaml
+++ b/src/components/schemas/invitation.yaml
@@ -133,7 +133,7 @@ invitation_in:
     delegatee_emails:
       type: array
       maxItems: 1
-      nullable: True
+      nullable: False
       items:
         $ref: './fields.yaml#/email'
       example: [ 'delegatee@example.com' ]

--- a/src/components/schemas/invitation.yaml
+++ b/src/components/schemas/invitation.yaml
@@ -54,7 +54,7 @@ invitation_in:
 
     approver_emails:
       type: array
-      maxLength: 3
+      maxItems: 3
       nullable: True
       items:
         $ref: './fields.yaml#/email'
@@ -123,3 +123,19 @@ invitation_in:
         $ref: './fields.yaml#/phone_number'
       description: |
         Mobile number of the employee
+
+    locale:
+      $ref: './fields.yaml#/locale'
+
+    mileage_settings:
+      $ref: './fields.yaml#/mileage_settings'
+
+    delegatee_emails:
+      type: array
+      maxItems: 1
+      nullable: True
+      items:
+        $ref: './fields.yaml#/email'
+      example: [ 'delegatee@example.com' ]
+      description: |
+        List of emails of employees that are delegatees for this employee.


### PR DESCRIPTION
### Changes

- Added following new keys in `POST admin/employees/invite/bulk`
  - locale
  - mileage_settings
  - delegatee_emails
- Removed redundant declarations of `locale` and `mileage_settings` keys
- `type: array` should have `maxItems` as key, not `maxLength`, fixed that