### PR TITLE
feat: Update `offset` description to display correct limit value

### DIFF
--- a/admin.yaml
+++ b/admin.yaml
@@ -91,11 +91,11 @@ components:
 
         For example, if there are 2000 objects, <br>
 
-        The first request will have offset as 0 and limit as 1000 to return
-        first 1000 objects. <br>
+        The first request will have offset as 0 and limit as 200 to return
+        first 200 objects. <br>
 
-        The second request will have offset as 1000 and limit as 1000 to return
-        next 1000 objects. <br>
+        The second request will have offset as 200 and limit as 200 to return
+        next 200 objects. <br>
       type: integer
       example: 10
     id_integer:

--- a/reference/accountant.yaml
+++ b/reference/accountant.yaml
@@ -50,8 +50,8 @@ components:
       description: |
         offset is used to skip that many number of objects before counting. <br>
         For example, if there are 2000 objects, <br>
-        The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
-        The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
+        The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
+        The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
       type: integer
       example: 10
     org_id:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -82,8 +82,8 @@ components:
       description: |
         offset is used to skip that many number of objects before counting. <br>
         For example, if there are 2000 objects, <br>
-        The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
-        The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
+        The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
+        The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
       type: integer
       example: 10
     id_integer:

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -68,8 +68,8 @@ components:
       description: |
         offset is used to skip that many number of objects before counting. <br>
         For example, if there are 2000 objects, <br>
-        The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
-        The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
+        The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
+        The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
       type: integer
       example: 10
     id_string:

--- a/reference/common.yaml
+++ b/reference/common.yaml
@@ -50,8 +50,8 @@ components:
       description: |
         offset is used to skip that many number of objects before counting. <br>
         For example, if there are 2000 objects, <br>
-        The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
-        The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
+        The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
+        The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
       type: integer
       example: 10
     place_out_minimal:

--- a/reference/hod.yaml
+++ b/reference/hod.yaml
@@ -51,8 +51,8 @@ components:
       description: |
         offset is used to skip that many number of objects before counting. <br>
         For example, if there are 2000 objects, <br>
-        The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
-        The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
+        The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
+        The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
       type: integer
       example: 10
     id_string:

--- a/reference/hop.yaml
+++ b/reference/hop.yaml
@@ -51,8 +51,8 @@ components:
       description: |
         offset is used to skip that many number of objects before counting. <br>
         For example, if there are 2000 objects, <br>
-        The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
-        The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
+        The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
+        The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
       type: integer
       example: 10
     id_string:

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -6690,8 +6690,8 @@ paths:
                     description: |
                       offset is used to skip that many number of objects before counting. <br>
                       For example, if there are 2000 objects, <br>
-                      The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
-                      The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
+                      The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
+                      The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
                     type: integer
                     example: 10
                   data:

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -69,8 +69,8 @@ components:
       description: |
         offset is used to skip that many number of objects before counting. <br>
         For example, if there are 2000 objects, <br>
-        The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
-        The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
+        The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
+        The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
       type: integer
       example: 10
     id_integer:
@@ -6690,8 +6690,8 @@ paths:
                     description: |
                       offset is used to skip that many number of objects before counting. <br>
                       For example, if there are 2000 objects, <br>
-                      The first request will have offset as 0 and limit as 1000 to return first 1000 objects. <br>
-                      The second request will have offset as 1000 and limit as 1000 to return next 1000 objects. <br>
+                      The first request will have offset as 0 and limit as 200 to return first 200 objects. <br>
+                      The second request will have offset as 200 and limit as 200 to return next 200 objects. <br>
                     type: integer
                     example: 10
                   data:

--- a/src/components/schemas/offset.yaml
+++ b/src/components/schemas/offset.yaml
@@ -3,10 +3,10 @@ description: >
 
   For example, if there are 2000 objects, <br>
 
-  The first request will have offset as 0 and limit as 1000 to return first 1000
+  The first request will have offset as 0 and limit as 200 to return first 200
   objects. <br>
 
-  The second request will have offset as 1000 and limit as 1000 to return next
-  1000 objects. <br>
+  The second request will have offset as 200 and limit as 200 to return next
+  200 objects. <br>
 type: integer
 example: 10


### PR DESCRIPTION
PC: https://app.clickup.com/t/85zu0ajzd
The customer was confused about why we showed a value of `1000` when the maximum limit for GET APIs was `200`.

Clickup: https://app.clickup.com/t/85zu1qmvv