### PR TITLE
fix: Fix the blog link to oauth2

### DIFF
--- a/docs/concepts/oauth2-application.md
+++ b/docs/concepts/oauth2-application.md
@@ -1,7 +1,7 @@
 
 # OAuth 2.0 Application
 
-This type of application is generally built by partners and are used by multiple organizations. Here is a non-boring blog that explains OAuth 2.0 in detail https://stories.fylehq.com/posts/the-non-boring-guide-to-oauth-2-0
+This type of application is generally built by partners and are used by multiple organizations. Here is a non-boring blog that explains OAuth 2.0 in detail https://stories.fylehq.com/p/the-non-boring-guide-to-oauth-20
 
 > #### 💡 Talk to us if you're interested in a partnership
 >


### PR DESCRIPTION
Fixed the broken link.

Before:
<img width="1437" alt="Screenshot 2023-11-08 at 1 00 59 PM" src="https://github.com/fylein/fyle-platform-docs/assets/22430409/af31e7d2-a050-41a1-8608-ffac443c7a3c">

After:
<img width="1440" alt="Screenshot 2023-11-08 at 1 01 30 PM" src="https://github.com/fylein/fyle-platform-docs/assets/22430409/d9584c29-78d6-41b8-a660-c9ccef39643b">
