### PR TITLE
adding file_ids in admin_expense_in for POST of admin/expenses

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -4099,6 +4099,15 @@ components:
           $ref: '#/components/schemas/locations'
         custom_fields:
           $ref: '#/components/schemas/custom_fields'
+        file_ids:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/fk_string'
+          description: |
+            List of file ids to attach to the expense. <br>
+            To add new files to the expense, send the list of file ids to be attached. <br>
+            To remove files from the expense, send the list of all file ids except which you want to remove. <br>
     accounting_export_summary_in:
       type: object
       required:

--- a/src/components/schemas/expense.yaml
+++ b/src/components/schemas/expense.yaml
@@ -960,6 +960,15 @@ admin_expense_in:
       $ref: './fields.yaml#/locations'
     custom_fields:
       $ref: './fields.yaml#/custom_fields'
+    file_ids:
+      type: array
+      items:
+        allOf:
+          - $ref: './fields.yaml#/fk_string'
+      description: |
+        List of file ids to attach to the expense. <br>
+        To add new files to the expense, send the list of file ids to be attached. <br>
+        To remove files from the expense, send the list of all file ids except which you want to remove. <br>
 
 approver_expense_in:
   type: object


### PR DESCRIPTION
Updated the docs of admin/expenses to view `file_ids` in the body.

click URL: https://app.clickup.com/t/86cun8r7y

The below images contain changes which would be made 

<img width="1428" alt="image" src="https://github.com/fylein/fyle-platform-docs/assets/159750587/4c7f94ab-a29e-4eb7-9fbe-365b84257243">

<img width="1426" alt="image" src="https://github.com/fylein/fyle-platform-docs/assets/159750587/3a7887ae-2bb3-4279-90d2-df19cd310293">
