### PR TITLE
feat: Add `card_nickname` to spend overview by corporate card API

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -10197,6 +10197,13 @@ components:
           description: |
             String denoting the name on the corporate card. This can be null.
           example: Jon Snow
+        card_nickname:
+          type: string
+          maxLength: 25
+          nullable: true
+          description: |
+            Unique nickname assigned to the card
+          example: Business Card
         user_id:
           type: string
           nullable: true

--- a/src/components/schemas/spend_overview.yaml
+++ b/src/components/schemas/spend_overview.yaml
@@ -104,6 +104,13 @@ spend_overview_by_corporate_card_data_out:
       description: |
         String denoting the name on the corporate card. This can be null.
       example: Jon Snow
+    card_nickname:
+      type: string
+      maxLength: 25
+      nullable: true
+      description: |
+        Unique nickname assigned to the card
+      example: 'Business Card'
     user_id:
       type: string
       nullable: true


### PR DESCRIPTION
Clickup: https://app.clickup.com/t/86cvgejcx

## Changes

<img width="451" alt="image" src="https://github.com/fylein/fyle-platform-docs/assets/54371867/59816d38-4433-48a0-a8be-2227da2fd7ba">

<img width="729" alt="image" src="https://github.com/fylein/fyle-platform-docs/assets/54371867/b2f09e6b-cccd-4834-8769-047500b900dc">
