### PR TITLE
feat: Add `delegatees` key to invitations POST + deprecation warning for old key

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -2061,6 +2061,27 @@ components:
       nullable: true
       description: Date-time in [ISO8601 format](https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14).
       example: '2020-06-01T01:18:19.292-08:00'
+    delegatee:
+      type: object
+      additionalProperties: false
+      properties:
+        user_id:
+          type: string
+          description: |
+            User ID of the delegatee.
+          example: uswjwgnwwgo
+        start_at:
+          allOf:
+            - $ref: '#/components/schemas/timestamptz_utc'
+          description: |
+            Date and time from which the delegation is active.
+          nullable: false
+        end_at:
+          allOf:
+            - $ref: '#/components/schemas/timestamptz_utc'
+          description: |
+            Date and time till which the delegation is active. If null, delegation is active indefinitely.
+          nullable: true
     invitation_in:
       type: object
       additionalProperties: false
@@ -2208,7 +2229,16 @@ components:
           example:
             - delegatee@example.com
           description: |
-            List of emails of employees that are delegatees for this employee.
+            This key is in the process of being deprecated. It is recommended to use `delegatees` instead.
+          deprecated: true
+        delegatees:
+          type: array
+          maxItems: 5
+          nullable: false
+          items:
+            $ref: '#/components/schemas/delegatee'
+          description: |
+            List of delegatees for this employee.
     employee_id:
       type: string
       maxLength: 255

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -2229,7 +2229,7 @@ components:
           example:
             - delegatee@example.com
           description: |
-            This key is in the process of being deprecated. It is recommended to use `delegatees` instead.
+            This key is in the process of being deprecated. It is recommended to use `delegatees` key instead.
           deprecated: true
         delegatees:
           type: array

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -1687,3 +1687,25 @@ has_accepted_invite:
   description: >
     This boolean field represents whether the employee has accepted the current org's invite by verifying his/her email or not.
   example: true
+
+delegatee:
+  type: object
+  additionalProperties: False
+  properties:
+    user_id:
+      type: string
+      description: |
+        User ID of the delegatee.
+      example: uswjwgnwwgo
+    start_at:
+      allOf:
+        - $ref: '#/timestamptz_utc'
+      description: |
+        Date and time from which the delegation is active.
+      nullable: False
+    end_at:
+      allOf:
+        - $ref: '#/timestamptz_utc'
+      description: |
+        Date and time till which the delegation is active. If null, delegation is active indefinitely.
+      nullable: True

--- a/src/components/schemas/invitation.yaml
+++ b/src/components/schemas/invitation.yaml
@@ -148,7 +148,7 @@ invitation_in:
         $ref: './fields.yaml#/email'
       example: [ 'delegatee@example.com' ]
       description: |
-        This key is in the process of being deprecated. It is recommended to use `delegatees` instead.
+        This key is in the process of being deprecated. It is recommended to use `delegatees` key instead.
       deprecated: true
 
     delegatees:

--- a/src/components/schemas/invitation.yaml
+++ b/src/components/schemas/invitation.yaml
@@ -148,4 +148,14 @@ invitation_in:
         $ref: './fields.yaml#/email'
       example: [ 'delegatee@example.com' ]
       description: |
-        List of emails of employees that are delegatees for this employee.
+        This key is in the process of being deprecated. It is recommended to use `delegatees` instead.
+      deprecated: true
+
+    delegatees:
+      type: array
+      maxItems: 5
+      nullable: False
+      items:
+        $ref: './fields.yaml#/delegatee'
+      description: |
+        List of delegatees for this employee.


### PR DESCRIPTION
https://app.clickup.com/t/86cvyz0t6

## Changes:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/6f53d2fd-7182-4207-8d50-d36dd522937b">
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/e83749e2-1bf9-4e14-bfb9-93fa4bcae4d4">
