### PR TITLE
feat: Additional fields POST /<role>/expenses

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -4158,7 +4158,36 @@ components:
       minItems: 0
       maxItems: 10
       items:
-        $ref: '#/components/schemas/location'
+        type: object
+        nullable: true
+        properties:
+          city:
+            type: string
+            nullable: true
+            example: London
+          state:
+            type: string
+            nullable: true
+            example: London
+          display:
+            type: string
+            nullable: true
+          country:
+            type: string
+            nullable: true
+            example: United Kingdom
+          formatted_address:
+            type: string
+            nullable: true
+            example: 221 Baker St, Marylebone, London, United Kingdom
+          latitude:
+            type: number
+            nullable: true
+            example: 12.971599
+          longitude:
+            type: number
+            nullable: true
+            example: 77.594566
     admin_expense_in:
       type: object
       additionalProperties: false
@@ -4210,6 +4239,8 @@ components:
               - Admins can't assign the expense to self.
         source:
           $ref: '#/components/schemas/source'
+        code:
+          $ref: '#/components/schemas/code'
         merchant:
           $ref: '#/components/schemas/merchant'
         foreign_currency:
@@ -4281,6 +4312,41 @@ components:
             List of file ids to attach to the expense. <br>
             To add new files to the expense, send the list of file ids to be attached. <br>
             To remove files from the expense, send the list of all file ids except which you want to remove. <br>
+        hotel_is_breakfast_provided:
+          type: boolean
+          nullable: true
+          description: |
+            This field is applicable for only `Hotel` category.
+        mileage_rate_id:
+          allOf:
+            - $ref: '#/components/schemas/fk_integer'
+          description: |
+            Specific to mileage expense. This represents the Mileage's rate id given by Fyle
+            during creation of mileage rate for which this expense is created.
+          nullable: true
+          example: 9080
+        mileage_is_round_trip:
+          type: boolean
+          nullable: true
+          description: Flag stating whether this was a round trip or not.
+        commute_details_id:
+          type: integer
+          nullable: true
+          description: |
+            Commute details id of the expense. This id is provided by Fyle to identify a commute details.
+          example: 1234
+        commute_deduction:
+          type: string
+          nullable: true
+          maxLength: 12
+          description: |
+            Commute deduction type of the expense.
+          example: ONE_WAY
+          enum:
+            - ONE_WAY
+            - ROUND_TRIP
+            - NO_DEDUCTION
+            - null
     attach_files_to_expense_in:
       type: object
       required:

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -2399,7 +2399,36 @@ components:
       minItems: 0
       maxItems: 10
       items:
-        $ref: '#/components/schemas/location'
+        type: object
+        nullable: true
+        properties:
+          city:
+            type: string
+            nullable: true
+            example: London
+          state:
+            type: string
+            nullable: true
+            example: London
+          display:
+            type: string
+            nullable: true
+          country:
+            type: string
+            nullable: true
+            example: United Kingdom
+          formatted_address:
+            type: string
+            nullable: true
+            example: 221 Baker St, Marylebone, London, United Kingdom
+          latitude:
+            type: number
+            nullable: true
+            example: 12.971599
+          longitude:
+            type: number
+            nullable: true
+            example: 77.594566
     custom_fields:
       type: array
       description: |
@@ -2437,6 +2466,8 @@ components:
           example: '2020-06-01T01:18:19.292-08:00'
         source:
           $ref: '#/components/schemas/source'
+        code:
+          $ref: '#/components/schemas/code'
         merchant:
           $ref: '#/components/schemas/merchant'
         foreign_currency:
@@ -2499,6 +2530,50 @@ components:
           $ref: '#/components/schemas/locations'
         custom_fields:
           $ref: '#/components/schemas/custom_fields'
+        file_ids:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/fk_string'
+          description: |
+            List of file ids to attach to the expense. <br>
+            To add new files to the expense, send the list of file ids to be attached. <br>
+            To remove files from the expense, send the list of all file ids except which you want to remove. <br>
+        hotel_is_breakfast_provided:
+          type: boolean
+          nullable: true
+          description: |
+            This field is applicable for only `Hotel` category.
+        mileage_rate_id:
+          allOf:
+            - $ref: '#/components/schemas/fk_integer'
+          description: |
+            Specific to mileage expense. This represents the Mileage's rate id given by Fyle
+            during creation of mileage rate for which this expense is created.
+          nullable: true
+          example: 9080
+        mileage_is_round_trip:
+          type: boolean
+          nullable: true
+          description: Flag stating whether this was a round trip or not.
+        commute_details_id:
+          type: integer
+          nullable: true
+          description: |
+            Commute details id of the expense. This id is provided by Fyle to identify a commute details.
+          example: 1234
+        commute_deduction:
+          type: string
+          nullable: true
+          maxLength: 12
+          description: |
+            Commute deduction type of the expense.
+          example: ONE_WAY
+          enum:
+            - ONE_WAY
+            - ROUND_TRIP
+            - NO_DEDUCTION
+            - null
     attach_files_to_expense_in:
       type: object
       required:

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -2244,7 +2244,36 @@ components:
       minItems: 0
       maxItems: 10
       items:
-        $ref: '#/components/schemas/location'
+        type: object
+        nullable: true
+        properties:
+          city:
+            type: string
+            nullable: true
+            example: London
+          state:
+            type: string
+            nullable: true
+            example: London
+          display:
+            type: string
+            nullable: true
+          country:
+            type: string
+            nullable: true
+            example: United Kingdom
+          formatted_address:
+            type: string
+            nullable: true
+            example: 221 Baker St, Marylebone, London, United Kingdom
+          latitude:
+            type: number
+            nullable: true
+            example: 12.971599
+          longitude:
+            type: number
+            nullable: true
+            example: 77.594566
     custom_fields:
       type: array
       description: |
@@ -2269,6 +2298,8 @@ components:
             This field is not required for creating Per Diem Expenses
         source:
           $ref: '#/components/schemas/source'
+        code:
+          $ref: '#/components/schemas/code'
         merchant:
           $ref: '#/components/schemas/merchant'
         foreign_currency:
@@ -2379,6 +2410,41 @@ components:
             List of file ids to attach to the expense. <br>
             To add new files to the expense, send the list of file ids to be attached. <br>
             To remove files from the expense, send the list of all file ids except which you want to remove. <br>
+        hotel_is_breakfast_provided:
+          type: boolean
+          nullable: true
+          description: |
+            This field is applicable for only `Hotel` category.
+        mileage_rate_id:
+          allOf:
+            - $ref: '#/components/schemas/fk_integer'
+          description: |
+            Specific to mileage expense. This represents the Mileage's rate id given by Fyle
+            during creation of mileage rate for which this expense is created.
+          nullable: true
+          example: 9080
+        mileage_is_round_trip:
+          type: boolean
+          nullable: true
+          description: Flag stating whether this was a round trip or not.
+        commute_details_id:
+          type: integer
+          nullable: true
+          description: |
+            Commute details id of the expense. This id is provided by Fyle to identify a commute details.
+          example: 1234
+        commute_deduction:
+          type: string
+          nullable: true
+          maxLength: 12
+          description: |
+            Commute deduction type of the expense.
+          example: ONE_WAY
+          enum:
+            - ONE_WAY
+            - ROUND_TRIP
+            - NO_DEDUCTION
+            - null
     expense_add_comment_action_in:
       type: object
       required:

--- a/src/components/schemas/expense.yaml
+++ b/src/components/schemas/expense.yaml
@@ -885,8 +885,18 @@ spender_expense_in:
       description: |
         Commute details id of the expense. This id is provided by Fyle to identify a commute details.
       example: 1234
-    commute_details:
-      $ref: './fields.yaml#/commute_details'
+    commute_deduction:
+      type: string
+      nullable: true
+      maxLength: 12
+      description: |
+        Commute deduction type of the expense.
+      example: ONE_WAY
+      enum:
+        - ONE_WAY
+        - ROUND_TRIP
+        - NO_DEDUCTION
+        - null
 
 admin_expense_in:
   type: object
@@ -1035,8 +1045,18 @@ admin_expense_in:
       description: |
         Commute details id of the expense. This id is provided by Fyle to identify a commute details.
       example: 1234
-    commute_details:
-      $ref: './fields.yaml#/commute_details'
+    commute_deduction:
+      type: string
+      nullable: true
+      maxLength: 12
+      description: |
+        Commute deduction type of the expense.
+      example: ONE_WAY
+      enum:
+        - ONE_WAY
+        - ROUND_TRIP
+        - NO_DEDUCTION
+        - null
 
 approver_expense_in:
   type: object
@@ -1165,8 +1185,18 @@ approver_expense_in:
       description: |
         Commute details id of the expense. This id is provided by Fyle to identify a commute details.
       example: 1234
-    commute_details:
-      $ref: './fields.yaml#/commute_details'
+    commute_deduction:
+      type: string
+      nullable: true
+      maxLength: 12
+      description: |
+        Commute deduction type of the expense.
+      example: ONE_WAY
+      enum:
+        - ONE_WAY
+        - ROUND_TRIP
+        - NO_DEDUCTION
+        - null
 
 expense_out_embed:
   type: object

--- a/src/components/schemas/expense.yaml
+++ b/src/components/schemas/expense.yaml
@@ -750,6 +750,8 @@ spender_expense_in:
         This field is not required for creating Per Diem Expenses
     source:
       $ref: './fields.yaml#/source'
+    code:
+      $ref: './fields.yaml#/code'
     merchant:
       $ref: './fields.yaml#/merchant'
     foreign_currency:
@@ -860,6 +862,31 @@ spender_expense_in:
         List of file ids to attach to the expense. <br>
         To add new files to the expense, send the list of file ids to be attached. <br>
         To remove files from the expense, send the list of all file ids except which you want to remove. <br>
+    hotel_is_breakfast_provided:
+      type: boolean
+      nullable: true
+      description: |
+        This field is applicable for only `Hotel` category.
+    mileage_rate_id:
+      allOf:
+        - $ref: './fields.yaml#/fk_integer'
+      description: |
+        Specific to mileage expense. This represents the Mileage's rate id given by Fyle
+        during creation of mileage rate for which this expense is created.
+      nullable: true
+      example: 9080
+    mileage_is_round_trip:
+      type: boolean
+      nullable: true
+      description: Flag stating whether this was a round trip or not.
+    commute_details_id:
+      type: integer
+      nullable: true
+      description: |
+        Commute details id of the expense. This id is provided by Fyle to identify a commute details.
+      example: 1234
+    commute_details:
+      $ref: './fields.yaml#/commute_details'
 
 admin_expense_in:
   type: object
@@ -912,6 +939,8 @@ admin_expense_in:
           - Admins can't assign the expense to self.
     source:
       $ref: './fields.yaml#/source'
+    code:
+      $ref: './fields.yaml#/code'
     merchant:
       $ref: './fields.yaml#/merchant'
     foreign_currency:
@@ -983,6 +1012,31 @@ admin_expense_in:
         List of file ids to attach to the expense. <br>
         To add new files to the expense, send the list of file ids to be attached. <br>
         To remove files from the expense, send the list of all file ids except which you want to remove. <br>
+    hotel_is_breakfast_provided:
+      type: boolean
+      nullable: true
+      description: |
+        This field is applicable for only `Hotel` category.
+    mileage_rate_id:
+      allOf:
+        - $ref: './fields.yaml#/fk_integer'
+      description: |
+        Specific to mileage expense. This represents the Mileage's rate id given by Fyle
+        during creation of mileage rate for which this expense is created.
+      nullable: true
+      example: 9080
+    mileage_is_round_trip:
+      type: boolean
+      nullable: true
+      description: Flag stating whether this was a round trip or not.
+    commute_details_id:
+      type: integer
+      nullable: true
+      description: |
+        Commute details id of the expense. This id is provided by Fyle to identify a commute details.
+      example: 1234
+    commute_details:
+      $ref: './fields.yaml#/commute_details'
 
 approver_expense_in:
   type: object
@@ -1015,6 +1069,8 @@ approver_expense_in:
       example: '2020-06-01T01:18:19.292-08:00'
     source:
       $ref: './fields.yaml#/source'
+    code:
+      $ref: './fields.yaml#/code'
     merchant:
       $ref: './fields.yaml#/merchant'
     foreign_currency:
@@ -1077,6 +1133,40 @@ approver_expense_in:
       $ref: './fields.yaml#/locations'
     custom_fields:
       $ref: './fields.yaml#/custom_fields'
+    file_ids:
+      type: array
+      items:
+        allOf:
+          - $ref: './fields.yaml#/fk_string'
+      description: |
+        List of file ids to attach to the expense. <br>
+        To add new files to the expense, send the list of file ids to be attached. <br>
+        To remove files from the expense, send the list of all file ids except which you want to remove. <br>
+    hotel_is_breakfast_provided:
+      type: boolean
+      nullable: true
+      description: |
+        This field is applicable for only `Hotel` category.
+    mileage_rate_id:
+      allOf:
+        - $ref: './fields.yaml#/fk_integer'
+      description: |
+        Specific to mileage expense. This represents the Mileage's rate id given by Fyle
+        during creation of mileage rate for which this expense is created.
+      nullable: true
+      example: 9080
+    mileage_is_round_trip:
+      type: boolean
+      nullable: true
+      description: Flag stating whether this was a round trip or not.
+    commute_details_id:
+      type: integer
+      nullable: true
+      description: |
+        Commute details id of the expense. This id is provided by Fyle to identify a commute details.
+      example: 1234
+    commute_details:
+      $ref: './fields.yaml#/commute_details'
 
 expense_out_embed:
   type: object

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -198,7 +198,36 @@ locations:
   minItems: 0
   maxItems: 10
   items:
-    $ref: './fields.yaml#/location'
+    type: object
+    nullable: true
+    properties:
+      city:
+        type: string
+        nullable: true
+        example: London
+      state:
+        type: string
+        nullable: true
+        example: London
+      display:
+        type: string
+        nullable: true
+      country:
+        type: string
+        nullable: true
+        example: United Kingdom
+      formatted_address:
+        type: string
+        nullable: true
+        example: '221 Baker St, Marylebone, London, United Kingdom'
+      latitude:
+        type: number
+        nullable: true
+        example: 12.971599
+      longitude:
+        type: number
+        nullable: true
+        example: 77.594566
 
 travel_classes:
   description: |


### PR DESCRIPTION
### Description
We have added support for 6 fields in the POST /<role>/expenses. 
Roles: 
- Admin
- Approver
- Spender

Fields added:
- code
- mileage_rate_id
- mileage_is_round_trip
- hote_is_breakfast_provided
- commute_details_id
- commute_details

We have also added support for file_ids in POST /approver/expenses.

Supporting screenshots:

1. POST /spender/expenses 
- Code 
<img width="664" alt="image" src="https://github.com/user-attachments/assets/d032d5ee-7dd4-4441-91cd-231556285826">

- Location fix
<img width="657" alt="image" src="https://github.com/user-attachments/assets/1d4fc5cd-311f-4cbb-b9e3-2ab86c9502f3">

- Additional fields
<img width="654" alt="image" src="https://github.com/user-attachments/assets/e1cc99a1-60c6-429e-a5cb-5d8b38954b8b">

2. POST /admin/expenses
- Code 
<img width="664" alt="image" src="https://github.com/user-attachments/assets/d032d5ee-7dd4-4441-91cd-231556285826">

- Location fix
<img width="657" alt="image" src="https://github.com/user-attachments/assets/1d4fc5cd-311f-4cbb-b9e3-2ab86c9502f3">

- Additional fields
<img width="654" alt="image" src="https://github.com/user-attachments/assets/e1cc99a1-60c6-429e-a5cb-5d8b38954b8b">


3. POST /admin/expenses
- Code 
<img width="664" alt="image" src="https://github.com/user-attachments/assets/d032d5ee-7dd4-4441-91cd-231556285826">

- Location fix
<img width="657" alt="image" src="https://github.com/user-attachments/assets/1d4fc5cd-311f-4cbb-b9e3-2ab86c9502f3">

- Additional fields and file IDs support
<img width="662" alt="image" src="https://github.com/user-attachments/assets/2671a4e8-61f7-47ec-8909-d3e9fce1478a">




## Clickup
https://app.clickup.com/1864988/v/l/1rx8w-41176