### PR TITLE
fix: remove Github access token used in github actions

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -65,5 +65,3 @@ jobs:
         author_email: siva@fylehq.com
         message: "Auto generate API docs"
         add: "./reference"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GIHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
### Description
removing Github access token used in github actions in platform-docs

## Clickup
https://app.clickup.com/t/86cwxbfue