### PR TITLE
feat: Revert approver file ids

### DIFF
--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -2536,15 +2536,6 @@ components:
           $ref: '#/components/schemas/locations'
         custom_fields:
           $ref: '#/components/schemas/custom_fields'
-        file_ids:
-          type: array
-          items:
-            allOf:
-              - $ref: '#/components/schemas/fk_string'
-          description: |
-            List of file ids to attach to the expense. <br>
-            To add new files to the expense, send the list of file ids to be attached. <br>
-            To remove files from the expense, send the list of all file ids except which you want to remove. <br>
         hotel_is_breakfast_provided:
           type: boolean
           nullable: true

--- a/src/components/schemas/expense.yaml
+++ b/src/components/schemas/expense.yaml
@@ -1152,15 +1152,6 @@ approver_expense_in:
       $ref: './fields.yaml#/locations'
     custom_fields:
       $ref: './fields.yaml#/custom_fields'
-    file_ids:
-      type: array
-      items:
-        allOf:
-          - $ref: './fields.yaml#/fk_string'
-      description: |
-        List of file ids to attach to the expense. <br>
-        To add new files to the expense, send the list of file ids to be attached. <br>
-        To remove files from the expense, send the list of all file ids except which you want to remove. <br>
     hotel_is_breakfast_provided:
       type: boolean
       nullable: true


### PR DESCRIPTION
### Description
Reverting file_ids support from `POST approver/expenses` PR #552  because this change is not live yet and this restricts other folks from publishing the docs to v1 branch.

## Clickup
https://app.clickup.com/1864988/v/l/1rx8w-41176