### PR TITLE
feat: updated API specs for expense_policy_rules to include new fields

### DIFF
--- a/src/admin/paths/admin@expense_policies.yaml
+++ b/src/admin/paths/admin@expense_policies.yaml
@@ -92,6 +92,16 @@ get:
       schema:
         type: string
         example: eq.true
+    - in: query
+      name: is_approver_policy
+      description: |
+        Whether to fetch expense policy rules that add an approver to an expense on violation.<br>
+        Supported operators are `eq`.<br>
+        is_approver_policy=eq.true <br>
+        is_approver_policy=eq.false
+      schema:
+        type: boolean
+        example: eq.true
     - $ref: '../../components/parameters/limit.yaml'
     - $ref: '../../components/parameters/offset.yaml'
   

--- a/src/components/schemas/expense_policies.yaml
+++ b/src/components/schemas/expense_policies.yaml
@@ -461,6 +461,17 @@ expense_policy_out:
       type: boolean
       description: |
         Whether the policy rule is retired and can't be made active again.
+    is_approver_policy:
+      type: boolean
+      description: |
+        Whether the policy rule adds an approver to the expense on violation.
+    approver_order:
+      type: number
+      nullable: true
+      description: |
+        This number indicates the order of the approver expense policy rule in the defined approval sequence. For non-approver policies, this field will be null.
+      minimum: 1
+      example: 3
     org_id:
       $ref: './fields.yaml#/org_id'
     created_at:

--- a/src/spender/paths/spender@expense_policies.yaml
+++ b/src/spender/paths/spender@expense_policies.yaml
@@ -37,6 +37,16 @@ get:
       schema:
         type: string
         example: eq.true
+    - in: query
+      name: is_approver_policy
+      description: |
+        Whether to fetch expense policy rules that add an approver to an expense on violation.<br>
+        Supported operators are `eq`.<br>
+        is_approver_policy=eq.true <br>
+        is_approver_policy=eq.false
+      schema:
+        type: boolean
+        example: eq.true
     - $ref: '../../components/parameters/limit.yaml'
     - $ref: '../../components/parameters/offset.yaml'
   


### PR DESCRIPTION
### Description
Updated API specs to include new fields(`approver_field` and `is_approver_policy`) added to the `expense_policy_rules` table and related `expense_policy_rules_rov` view.
Following endpoints were updated -
- GET /spender/expense_policy_rules
- GET /admin/expense_policy_rules
- POST /admin/expense_policy_rules
- POST /admin/expense_policy_rules/enable
- POST /admin/expense_policy_rules/disable

## Clickup
https://app.clickup.com/t/86cxr6388