### PR TITLE
fix: type fix for `GET /expense_policy_rules` query param `is_approver_policy`

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -23137,7 +23137,7 @@ paths:
             is_approver_policy=eq.true <br>
             is_approver_policy=eq.false
           schema:
-            type: boolean
+            type: string
             example: eq.true
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -12764,7 +12764,7 @@ paths:
             is_approver_policy=eq.true <br>
             is_approver_policy=eq.false
           schema:
-            type: boolean
+            type: string
             example: eq.true
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'

--- a/src/admin/paths/admin@expense_policies.yaml
+++ b/src/admin/paths/admin@expense_policies.yaml
@@ -100,7 +100,7 @@ get:
         is_approver_policy=eq.true <br>
         is_approver_policy=eq.false
       schema:
-        type: boolean
+        type: string
         example: eq.true
     - $ref: '../../components/parameters/limit.yaml'
     - $ref: '../../components/parameters/offset.yaml'

--- a/src/spender/paths/spender@expense_policies.yaml
+++ b/src/spender/paths/spender@expense_policies.yaml
@@ -45,7 +45,7 @@ get:
         is_approver_policy=eq.true <br>
         is_approver_policy=eq.false
       schema:
-        type: boolean
+        type: string
         example: eq.true
     - $ref: '../../components/parameters/limit.yaml'
     - $ref: '../../components/parameters/offset.yaml'


### PR DESCRIPTION
### Description
- This fixes the issue from specs [PR](https://github.com/fylein/fyle-platform-docs/pull/595) related to `/expense_policy_rules`
- The `is_approver_policy` param was defined as `boolean` causing platform-api tests to fail.
- Reason: query param value passed was `eq.true` which is not a valid `boolean` value.

### APIs updated - 
- GET /spender/expense_policy_rules
![image](https://github.com/user-attachments/assets/ac4cf1ed-9358-43af-9e36-738976325bb7)

- GET /admin/expense_policy_rules
![image](https://github.com/user-attachments/assets/5faf9cb8-d95f-456e-a3ed-e3bc806a2758)

## Clickup
https://app.clickup.com/t/86cxr6388