### PR TITLE
feat: allow `expense_policy_rules.creator_user` object to be `nullable`

### DIFF
--- a/src/components/schemas/expense_policies.yaml
+++ b/src/components/schemas/expense_policies.yaml
@@ -843,7 +843,7 @@ expense_policy_out:
     creator_user_id:
       $ref: './fields.yaml#/user_id'
     creator_user:
-      $ref: ./user.yaml#/user_out_embed
+      $ref: ./user.yaml#/user_out_embed_nullable
 
 
 expense_policy_state_change_in:


### PR DESCRIPTION
### Description
- For `DEFAULT_PRIMARY_APPROVER_POLICY` the `creator_user` object is returned as null since no system user exists in DB.
- This breaks certain platform-api tests where the response expects this field to be null.

## Clickup
https://app.clickup.com/t/86cxr0gcm