### PR TITLE
feat: updated specs post adding new fields to `individual desired states`

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -12371,6 +12371,28 @@ components:
           example:
             - usBdsdfscl
             - usLSsdfwqt
+        approver_policy_order:
+          type: integer
+          nullable: true
+          description: |
+            This represents the order of the approver policy related to this individual desired state record.
+            If the policy does not add any approver, this field will be null.
+          example: 1
+        approver_source:
+          type: string
+          enum:
+            - PRIMARY_APPROVER
+            - SECONDARY_APPROVER_1
+            - SECONDARY_APPROVER_2
+            - PROJECT_APPROVER_1
+            - PROJECT_APPROVER_2
+            - DEPARTMENT_HEAD_APPROVER
+            - EMAIL_APPROVER
+          nullable: true
+          description: |
+            This represents the type of approver(source) that was added by the approver policy related to this individual
+            desired state record. If the policy does not add any approver, this field will be null.
+          example: PROJECT_APPROVER_1
         run_status:
           nullable: false
           type: string

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -14221,6 +14221,28 @@ components:
           example:
             - usBdsdfscl
             - usLSsdfwqt
+        approver_policy_order:
+          type: integer
+          nullable: true
+          description: |
+            This represents the order of the approver policy related to this individual desired state record.
+            If the policy does not add any approver, this field will be null.
+          example: 1
+        approver_source:
+          type: string
+          enum:
+            - PRIMARY_APPROVER
+            - SECONDARY_APPROVER_1
+            - SECONDARY_APPROVER_2
+            - PROJECT_APPROVER_1
+            - PROJECT_APPROVER_2
+            - DEPARTMENT_HEAD_APPROVER
+            - EMAIL_APPROVER
+          nullable: true
+          description: |
+            This represents the type of approver(source) that was added by the approver policy related to this individual
+            desired state record. If the policy does not add any approver, this field will be null.
+          example: PROJECT_APPROVER_1
         expense_policy_rule_id:
           type: string
           description: |

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -4162,6 +4162,28 @@ components:
           example:
             - usBdsdfscl
             - usLSsdfwqt
+        approver_policy_order:
+          type: integer
+          nullable: true
+          description: |
+            This represents the order of the approver policy related to this individual desired state record.
+            If the policy does not add any approver, this field will be null.
+          example: 1
+        approver_source:
+          type: string
+          enum:
+            - PRIMARY_APPROVER
+            - SECONDARY_APPROVER_1
+            - SECONDARY_APPROVER_2
+            - PROJECT_APPROVER_1
+            - PROJECT_APPROVER_2
+            - DEPARTMENT_HEAD_APPROVER
+            - EMAIL_APPROVER
+          nullable: true
+          description: |
+            This represents the type of approver(source) that was added by the approver policy related to this individual
+            desired state record. If the policy does not add any approver, this field will be null.
+          example: PROJECT_APPROVER_1
         expense_policy_rule_id:
           type: string
           description: |

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -3369,6 +3369,28 @@ components:
           example:
             - usBdsdfscl
             - usLSsdfwqt
+        approver_policy_order:
+          type: integer
+          nullable: true
+          description: |
+            This represents the order of the approver policy related to this individual desired state record.
+            If the policy does not add any approver, this field will be null.
+          example: 1
+        approver_source:
+          type: string
+          enum:
+            - PRIMARY_APPROVER
+            - SECONDARY_APPROVER_1
+            - SECONDARY_APPROVER_2
+            - PROJECT_APPROVER_1
+            - PROJECT_APPROVER_2
+            - DEPARTMENT_HEAD_APPROVER
+            - EMAIL_APPROVER
+          nullable: true
+          description: |
+            This represents the type of approver(source) that was added by the approver policy related to this individual
+            desired state record. If the policy does not add any approver, this field will be null.
+          example: PROJECT_APPROVER_1
         run_status:
           nullable: false
           type: string

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -7544,6 +7544,28 @@ components:
           example:
             - usBdsdfscl
             - usLSsdfwqt
+        approver_policy_order:
+          type: integer
+          nullable: true
+          description: |
+            This represents the order of the approver policy related to this individual desired state record.
+            If the policy does not add any approver, this field will be null.
+          example: 1
+        approver_source:
+          type: string
+          enum:
+            - PRIMARY_APPROVER
+            - SECONDARY_APPROVER_1
+            - SECONDARY_APPROVER_2
+            - PROJECT_APPROVER_1
+            - PROJECT_APPROVER_2
+            - DEPARTMENT_HEAD_APPROVER
+            - EMAIL_APPROVER
+          nullable: true
+          description: |
+            This represents the type of approver(source) that was added by the approver policy related to this individual
+            desired state record. If the policy does not add any approver, this field will be null.
+          example: PROJECT_APPROVER_1
         run_status:
           nullable: false
           type: string

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -7864,6 +7864,28 @@ components:
           example:
             - usBdsdfscl
             - usLSsdfwqt
+        approver_policy_order:
+          type: integer
+          nullable: true
+          description: |
+            This represents the order of the approver policy related to this individual desired state record.
+            If the policy does not add any approver, this field will be null.
+          example: 1
+        approver_source:
+          type: string
+          enum:
+            - PRIMARY_APPROVER
+            - SECONDARY_APPROVER_1
+            - SECONDARY_APPROVER_2
+            - PROJECT_APPROVER_1
+            - PROJECT_APPROVER_2
+            - DEPARTMENT_HEAD_APPROVER
+            - EMAIL_APPROVER
+          nullable: true
+          description: |
+            This represents the type of approver(source) that was added by the approver policy related to this individual
+            desired state record. If the policy does not add any approver, this field will be null.
+          example: PROJECT_APPROVER_1
         expense_policy_rule_id:
           type: string
           description: |

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -503,6 +503,28 @@ expense_policy_individual_desired_states:
       example:
         - usBdsdfscl
         - usLSsdfwqt
+    approver_policy_order:
+      type: integer
+      nullable: true
+      description: |
+        This represents the order of the approver policy related to this individual desired state record.
+        If the policy does not add any approver, this field will be null.
+      example: 1
+    approver_source:
+      type: string
+      enum:
+        - PRIMARY_APPROVER
+        - SECONDARY_APPROVER_1
+        - SECONDARY_APPROVER_2
+        - PROJECT_APPROVER_1
+        - PROJECT_APPROVER_2
+        - DEPARTMENT_HEAD_APPROVER
+        - EMAIL_APPROVER
+      nullable: true
+      description: |
+        This represents the type of approver(source) that was added by the approver policy related to this individual
+        desired state record. If the policy does not add any approver, this field will be null.
+      example: 'PROJECT_APPROVER_1'
     run_status:
       nullable: false
       type: string

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -391,6 +391,28 @@ expense_check_policies_individual_desired_states:
       example:
         - usBdsdfscl
         - usLSsdfwqt
+    approver_policy_order:
+      type: integer
+      nullable: true
+      description: |
+        This represents the order of the approver policy related to this individual desired state record.
+        If the policy does not add any approver, this field will be null.
+      example: 1
+    approver_source:
+      type: string
+      enum:
+        - PRIMARY_APPROVER
+        - SECONDARY_APPROVER_1
+        - SECONDARY_APPROVER_2
+        - PROJECT_APPROVER_1
+        - PROJECT_APPROVER_2
+        - DEPARTMENT_HEAD_APPROVER
+        - EMAIL_APPROVER
+      nullable: true
+      description: |
+        This represents the type of approver(source) that was added by the approver policy related to this individual
+        desired state record. If the policy does not add any approver, this field will be null.
+      example: 'PROJECT_APPROVER_1'
     expense_policy_rule_id:
       type: string
       description: |


### PR DESCRIPTION
### Description
Updated specs for APIs returning `individual desired states` objects as response.

Fields added to `individual desired states` objects - 
- `approver_policy_order`
- `approver_order`

APIs updated - 
- GET /spender/expenses/expense_policy_states
![image](https://github.com/user-attachments/assets/e2122ea5-dfe8-4318-b0a5-e12fa009e83a)

- GET /approver/expenses/expense_policy_states
![image](https://github.com/user-attachments/assets/c258a82b-0c88-4513-ae1e-6a438f8d98ba)

- GET /admin/expenses/expense_policy_states
![image](https://github.com/user-attachments/assets/ccbdee60-9b1b-45ac-9329-dc5ac9e662d4)

- POST /spender/expenses/check_policies
![image](https://github.com/user-attachments/assets/4d9d32da-f8dd-48b4-9a19-2f9b87e3f968)

- POST /spender/expenses/split/check_policies
![image](https://github.com/user-attachments/assets/cbbbb019-1ece-4ae9-9644-8a01687507ff)

- POST /approver/expenses/split/check_policies
![image](https://github.com/user-attachments/assets/ab520aff-8274-4d62-b1e2-cbec03039d5e)

- POST /admin/expenses/split/check_policies
![image](https://github.com/user-attachments/assets/c911b097-83cb-4427-b1df-628fe9043cf1)

- POST /spender/expenses/check_policies/bulk
![image](https://github.com/user-attachments/assets/77039f71-a393-4c35-afe6-ce90057c1c13)

## Clickup
https://app.clickup.com/t/86cxr0u83