### PR TITLE
fix: added `null` to `approver_source` enum values

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -12388,6 +12388,7 @@ components:
             - PROJECT_APPROVER_2
             - DEPARTMENT_HEAD_APPROVER
             - EMAIL_APPROVER
+            - null
           nullable: true
           description: |
             This represents the type of approver(source) that was added by the approver policy related to this individual
@@ -14238,6 +14239,7 @@ components:
             - PROJECT_APPROVER_2
             - DEPARTMENT_HEAD_APPROVER
             - EMAIL_APPROVER
+            - null
           nullable: true
           description: |
             This represents the type of approver(source) that was added by the approver policy related to this individual

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -3386,6 +3386,7 @@ components:
             - PROJECT_APPROVER_2
             - DEPARTMENT_HEAD_APPROVER
             - EMAIL_APPROVER
+            - null
           nullable: true
           description: |
             This represents the type of approver(source) that was added by the approver policy related to this individual
@@ -4179,6 +4180,7 @@ components:
             - PROJECT_APPROVER_2
             - DEPARTMENT_HEAD_APPROVER
             - EMAIL_APPROVER
+            - null
           nullable: true
           description: |
             This represents the type of approver(source) that was added by the approver policy related to this individual

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -7561,6 +7561,7 @@ components:
             - PROJECT_APPROVER_2
             - DEPARTMENT_HEAD_APPROVER
             - EMAIL_APPROVER
+            - null
           nullable: true
           description: |
             This represents the type of approver(source) that was added by the approver policy related to this individual
@@ -7881,6 +7882,7 @@ components:
             - PROJECT_APPROVER_2
             - DEPARTMENT_HEAD_APPROVER
             - EMAIL_APPROVER
+            - null
           nullable: true
           description: |
             This represents the type of approver(source) that was added by the approver policy related to this individual

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -408,6 +408,7 @@ expense_check_policies_individual_desired_states:
         - PROJECT_APPROVER_2
         - DEPARTMENT_HEAD_APPROVER
         - EMAIL_APPROVER
+        - null
       nullable: true
       description: |
         This represents the type of approver(source) that was added by the approver policy related to this individual
@@ -542,6 +543,7 @@ expense_policy_individual_desired_states:
         - PROJECT_APPROVER_2
         - DEPARTMENT_HEAD_APPROVER
         - EMAIL_APPROVER
+        - null
       nullable: true
       description: |
         This represents the type of approver(source) that was added by the approver policy related to this individual


### PR DESCRIPTION
### Description
Added `null` as an enum value for the `approver_source` field.

Reason -
- The `approver_source` field is defined as `nullable` but the `platform-api` yaml tests fail if these spec changes are included and some tests return `null` as a value for this field.
- This is due to some limitation/issue on `OpenAPI's` side.

Affected APIs - (by affected we mean those where `null` will be shown as an enum value for `approver_source` field)
- GET /spender/expenses/expense_policy_states
- GET /approver/expenses/expense_policy_states
- GET /admin/expenses/expense_policy_states
- POST /spender/expenses/check_policies
- POST /spender/expenses/split/check_policies
- POST /approver/expenses/split/check_policies
- POST /admin/expenses/split/check_policies
- POST /spender/expenses/check_policies/bulk

## Clickup
https://app.clickup.com/t/86cxr0u83