### PR TITLE
feat: add `rank` field to the `reports_rot.approvals` array objects.

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -2913,12 +2913,15 @@ components:
             - APPROVAL_DONE
           description: |
             State of this report_approval
-        rank:
+        approver_order:
           type: integer
           description: |
-            This number inidicates the order of the approver in the approval sequence for the report.
-            The approver with the lowest rank is the first approver in the sequence.
-          example: 0
+            This number inidicates the order of the approver in the approval
+            sequence for the report.
+
+            The approver with the lowest approver_order is the first approver in
+            the sequence.
+          example: 1
     report_out_embed:
       type: object
       nullable: true

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -2916,11 +2916,8 @@ components:
         approver_order:
           type: integer
           description: |
-            This number inidicates the order of the approver in the approval
-            sequence for the report.
-
-            The approver with the lowest approver_order is the first approver in
-            the sequence.
+            This number inidicates the order of the approver in the approval sequence for the report.
+            The approver with the lowest approver_order is the first approver in the sequence.
           example: 1
     report_out_embed:
       type: object

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -2913,6 +2913,12 @@ components:
             - APPROVAL_DONE
           description: |
             State of this report_approval
+        rank:
+          type: integer
+          description: |
+            This number inidicates the order of the approver in the approval sequence for the report.
+            The approver with the lowest rank is the first approver in the sequence.
+          example: 0
     report_out_embed:
       type: object
       nullable: true

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -11421,6 +11421,18 @@ components:
           description: |
             This represents the description of the expense policy rule.
           example: Receipt is mandatory for expense above $50
+        source:
+          type: string
+          enum:
+            - WEBAPP_POLICY_FORM
+            - WEBAPP_POLICY_JSON
+            - WEBAPP_EXPENSE_RECEIPT_AMOUNT_LIMIT
+            - WEBAPP_EXPENSE_MILEAGE_SLAB_RATE
+            - WEBAPP_PROJECT_APPROVAL
+            - DEFAULT_PRIMARY_APPROVER_POLICY
+          description: |
+            This represents the source of the expense policy rule, i.e. from where it was created.
+          example: WEBAPP_POLICY_FORM
         is_enabled:
           type: boolean
           description: |

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -151,11 +151,8 @@ components:
         approver_order:
           type: integer
           description: |
-            This number inidicates the order of the approver in the approval
-            sequence for the report.
-
-            The approver with the lowest approver_order is the first approver in
-            the sequence.
+            This number inidicates the order of the approver in the approval sequence for the report.
+            The approver with the lowest approver_order is the first approver in the sequence.
           example: 1
     employee_id:
       type: string

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -148,12 +148,15 @@ components:
             - APPROVAL_DONE
           description: |
             State of this report_approval
-        rank:
+        approver_order:
           type: integer
           description: |
-            This number inidicates the order of the approver in the approval sequence for the report.
-            The approver with the lowest rank is the first approver in the sequence.
-          example: 0
+            This number inidicates the order of the approver in the approval
+            sequence for the report.
+
+            The approver with the lowest approver_order is the first approver in
+            the sequence.
+          example: 1
     employee_id:
       type: string
       maxLength: 255

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -148,6 +148,12 @@ components:
             - APPROVAL_DONE
           description: |
             State of this report_approval
+        rank:
+          type: integer
+          description: |
+            This number inidicates the order of the approver in the approval sequence for the report.
+            The approver with the lowest rank is the first approver in the sequence.
+          example: 0
     employee_id:
       type: string
       maxLength: 255

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -7058,6 +7058,18 @@ components:
           description: |
             This represents the description of the expense policy rule.
           example: Receipt is mandatory for expense above $50
+        source:
+          type: string
+          enum:
+            - WEBAPP_POLICY_FORM
+            - WEBAPP_POLICY_JSON
+            - WEBAPP_EXPENSE_RECEIPT_AMOUNT_LIMIT
+            - WEBAPP_EXPENSE_MILEAGE_SLAB_RATE
+            - WEBAPP_PROJECT_APPROVAL
+            - DEFAULT_PRIMARY_APPROVER_POLICY
+          description: |
+            This represents the source of the expense policy rule, i.e. from where it was created.
+          example: WEBAPP_POLICY_FORM
         is_enabled:
           type: boolean
           description: |

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -884,11 +884,8 @@ components:
         approver_order:
           type: integer
           description: |
-            This number inidicates the order of the approver in the approval
-            sequence for the report.
-
-            The approver with the lowest approver_order is the first approver in
-            the sequence.
+            This number inidicates the order of the approver in the approval sequence for the report.
+            The approver with the lowest approver_order is the first approver in the sequence.
           example: 1
     report_out_embed:
       type: object

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -881,12 +881,15 @@ components:
             - APPROVAL_DONE
           description: |
             State of this report_approval
-        rank:
+        approver_order:
           type: integer
           description: |
-            This number inidicates the order of the approver in the approval sequence for the report.
-            The approver with the lowest rank is the first approver in the sequence.
-          example: 0
+            This number inidicates the order of the approver in the approval
+            sequence for the report.
+
+            The approver with the lowest approver_order is the first approver in
+            the sequence.
+          example: 1
     report_out_embed:
       type: object
       nullable: true

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -881,6 +881,12 @@ components:
             - APPROVAL_DONE
           description: |
             State of this report_approval
+        rank:
+          type: integer
+          description: |
+            This number inidicates the order of the approver in the approval sequence for the report.
+            The approver with the lowest rank is the first approver in the sequence.
+          example: 0
     report_out_embed:
       type: object
       nullable: true

--- a/src/components/schemas/expense_policies.yaml
+++ b/src/components/schemas/expense_policies.yaml
@@ -453,6 +453,18 @@ expense_policy_out:
       description: |
         This represents the description of the expense policy rule.
       example: Receipt is mandatory for expense above $50
+    source:
+      type: string
+      enum:
+        - WEBAPP_POLICY_FORM
+        - WEBAPP_POLICY_JSON
+        - WEBAPP_EXPENSE_RECEIPT_AMOUNT_LIMIT
+        - WEBAPP_EXPENSE_MILEAGE_SLAB_RATE
+        - WEBAPP_PROJECT_APPROVAL
+        - DEFAULT_PRIMARY_APPROVER_POLICY
+      description: |
+        This represents the source of the expense policy rule, i.e. from where it was created.
+      example: 'WEBAPP_POLICY_FORM'
     is_enabled:
       type: boolean
       description: |

--- a/src/components/schemas/report_approval.yaml
+++ b/src/components/schemas/report_approval.yaml
@@ -16,3 +16,9 @@ report_approval_out_embed:
         - APPROVAL_DONE
       description: |
         State of this report_approval
+    rank:
+      type: integer
+      description: |
+        This number inidicates the order of the approver in the approval sequence for the report.
+        The approver with the lowest rank is the first approver in the sequence.
+      example: 0

--- a/src/components/schemas/report_approval.yaml
+++ b/src/components/schemas/report_approval.yaml
@@ -16,9 +16,9 @@ report_approval_out_embed:
         - APPROVAL_DONE
       description: |
         State of this report_approval
-    rank:
+    approver_order:
       type: integer
       description: |
         This number inidicates the order of the approver in the approval sequence for the report.
-        The approver with the lowest rank is the first approver in the sequence.
-      example: 0
+        The approver with the lowest approver_order is the first approver in the sequence.
+      example: 1


### PR DESCRIPTION
### Description
- We include the `report_approvals.rank` field in the `reports_rot.approvals` minimal objects array.
- This is required for `simplify_multi_stage_approvals` initiative.
- We have a UI requirement where the approvers of a report need to be shown in the sequence they are present in.

Updated APIs - 
- GET /spender/reports
![image](https://github.com/user-attachments/assets/f24b70d4-9b49-4b0d-a8a2-947f852a4ec6)

- GET /approver/reports
![image](https://github.com/user-attachments/assets/38f601a5-cdbc-45a4-b89c-166eedcce0ed)

- GET /admin/reports (including SS for `Response Sample` here)
![image](https://github.com/user-attachments/assets/2fc65665-b40e-42a9-807a-cbc9d4ef0d3a)


Other APIs(create, submit, resubmit, add_approver, etc.) that return the entire `reports_rov/rot` in the response will also have this new field. But, the above APIs are the ones most relevant to us as of now.

## Clickup
https://app.clickup.com/t/86cy1wukp