### PR TITLE
feat: `POST /admin/expense_policy_rules/reorder` API specs

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -23442,6 +23442,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/404'
+  /admin/expense_policy_rules/reorder:
+    post:
+      tags:
+        - Expense Policies
+      summary: Reorder approver policies
+      description: |
+        Reorder the enabled approver policies of an org.
+        - An **approver policy** is a policy that adds an approver to an expense on violation.
+        - All **enabled** approver policy IDs must be provided in the request body.
+      operationId: expense_policy_rules_reorder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/expense_policy_state_change_in'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400'
+        '401':
+          description: Unauthorized request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
   /admin/expense_policy_states:
     get:
       tags:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -23485,6 +23485,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/401'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/403'
   /admin/expense_policy_states:
     get:
       tags:

--- a/src/admin/openapi.yaml
+++ b/src/admin/openapi.yaml
@@ -418,6 +418,8 @@ paths:
     $ref: paths/admin@expense_policies@enable.yaml
   /admin/expense_policy_rules/disable:
     $ref: paths/admin@expense_policies@disable.yaml
+  /admin/expense_policy_rules/reorder:
+    $ref: paths/admin@expense_policies@reorder.yaml
   /admin/expense_policy_states:
     $ref: paths/admin@expense_policies@states.yaml
   /admin/statements:

--- a/src/admin/paths/admin@expense_policies@reorder.yaml
+++ b/src/admin/paths/admin@expense_policies@reorder.yaml
@@ -1,0 +1,42 @@
+post:
+  tags:
+    - Expense Policies
+  summary: Reorder approver policies
+  description: |
+    Reorder the enabled approver policies of an org.
+    - An **approver policy** is a policy that adds an approver to an expense on violation.
+    - All **enabled** approver policy IDs must be provided in the request body.
+  operationId: expense_policy_rules_reorder
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: False
+          required:
+            - data
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '../../components/schemas/expense_policies.yaml#/expense_policy_state_change_in'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/400.yaml
+    '401':
+      description: Unauthorized request
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/401.yaml

--- a/src/admin/paths/admin@expense_policies@reorder.yaml
+++ b/src/admin/paths/admin@expense_policies@reorder.yaml
@@ -40,3 +40,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/401.yaml
+    '403':
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/403.yaml"


### PR DESCRIPTION
### Description
- Added new API to reorder approver policies.
- This is used for `simplified_multi_stage_approvals` feature.

API docs preview -
- POST /admin/expense_policy_rules/reorder
![image](https://github.com/user-attachments/assets/eb30b3a6-2737-4290-84a0-310eded307e8)



## Clickup
https://app.clickup.com/t/86cxr0j1t