### PR TITLE
feat: Add Docs for Expense Comments `GET` APIs

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -14045,6 +14045,7 @@ components:
         action_data:
           type: object
           description: Data related to expense action.
+          nullable: true
         expense_id:
           $ref: '#/components/schemas/id_string'
         creator_type:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -1711,13 +1711,6 @@ components:
         The unique id of an user to which the object is associated.
       readOnly: true
       example: uswjwgnwwgo
-    user_id_nullable:
-      type: string
-      description: |
-        The unique id of an user to which the object is associated.
-      readOnly: true
-      nullable: true
-      example: uswjwgnwwgo
     user_full_name:
       type: string
       maxLength: 255
@@ -14000,6 +13993,13 @@ components:
             - 12423
           description: |
             List of IDs of expense fields which are mandatory but are missing.
+    user_id_nullable:
+      type: string
+      description: |
+        The unique id of an user to which the object is associated.
+      readOnly: true
+      nullable: true
+      example: uswjwgnwwgo
     expense_comments_out:
       type: object
       additionalProperties: false

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -24402,7 +24402,7 @@ paths:
       tags:
         - Expenses
       summary: List expense comments
-      description: List all the comments of on expense
+      description: List all the comments of an expense
       operationId: expense_comments_get
       parameters:
         - $ref: '#/components/parameters/expense_id'

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -6204,73 +6204,6 @@ components:
           $ref: '#/components/schemas/updated_at'
         org_id:
           $ref: '#/components/schemas/id_string'
-    expense_comments_out:
-      type: object
-      additionalProperties: false
-      required:
-        - id
-        - comment
-        - action
-        - action_data
-        - expense_id
-        - creator_type
-        - creator_user_id
-        - creator_user
-        - org_id
-        - updated_at
-        - created_at
-      properties:
-        id:
-          $ref: '#/components/schemas/id_string'
-        comment:
-          type: string
-          description: comment on the report
-          example: We don't accept laundry bills
-        action:
-          type: string
-          description: Expense action for which comment is added.
-          enum:
-            - ADMIN_APPROVED
-            - APPROVED
-            - APPROVER_REMOVED
-            - AUTO_MATCHED
-            - AUTO_MERGED
-            - COMMENTED
-            - DATA_EXTRACTED
-            - EJECTED_FROM_REPORT
-            - EXPENSE_RULE_APPLIED
-            - FILE_ATTACHED
-            - FILE_DELETED
-            - INVALID_EXPENSE_FIELD_REMOVED
-            - MATCHED
-            - PAID
-            - PARTIALLY_APPROVED
-            - POLICY_RESULT_APPLIED
-            - UNMATCHED
-          example: APPROVED
-        action_data:
-          type: object
-          description: Data related to expense action.
-        expense_id:
-          $ref: '#/components/schemas/id_string'
-        creator_type:
-          type: string
-          description: Describes whether the comment is system-generated or User made.
-          enum:
-            - SYSTEM
-            - POLICY
-            - USER
-          example: USER
-        creator_user_id:
-          $ref: '#/components/schemas/id_string'
-        creator_user:
-          $ref: '#/components/schemas/user_out_embed_nullable'
-        created_at:
-          $ref: '#/components/schemas/created_at'
-        updated_at:
-          $ref: '#/components/schemas/updated_at'
-        org_id:
-          $ref: '#/components/schemas/id_string'
     add_approver_in:
       type: object
       additionalProperties: false
@@ -14060,6 +13993,73 @@ components:
             - 12423
           description: |
             List of IDs of expense fields which are mandatory but are missing.
+    expense_comments_out:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - comment
+        - action
+        - action_data
+        - expense_id
+        - creator_type
+        - creator_user_id
+        - creator_user
+        - org_id
+        - updated_at
+        - created_at
+      properties:
+        id:
+          $ref: '#/components/schemas/id_string'
+        comment:
+          type: string
+          description: comment on the report
+          example: We don't accept laundry bills
+        action:
+          type: string
+          description: Expense action for which comment is added.
+          enum:
+            - ADMIN_APPROVED
+            - APPROVED
+            - APPROVER_REMOVED
+            - AUTO_MATCHED
+            - AUTO_MERGED
+            - COMMENTED
+            - DATA_EXTRACTED
+            - EJECTED_FROM_REPORT
+            - EXPENSE_RULE_APPLIED
+            - FILE_ATTACHED
+            - FILE_DELETED
+            - INVALID_EXPENSE_FIELD_REMOVED
+            - MATCHED
+            - PAID
+            - PARTIALLY_APPROVED
+            - POLICY_RESULT_APPLIED
+            - UNMATCHED
+          example: APPROVED
+        action_data:
+          type: object
+          description: Data related to expense action.
+        expense_id:
+          $ref: '#/components/schemas/id_string'
+        creator_type:
+          type: string
+          description: Describes whether the comment is system-generated or User made.
+          enum:
+            - SYSTEM
+            - POLICY
+            - USER
+          example: USER
+        creator_user_id:
+          $ref: '#/components/schemas/user_id'
+        creator_user:
+          $ref: '#/components/schemas/user_out_embed_nullable'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        org_id:
+          $ref: '#/components/schemas/org_id'
     expense_dismiss_duplicates_in:
       type: object
       required:
@@ -14702,15 +14702,6 @@ components:
       schema:
         type: string
         example: in.(bacc1234,bacc4567)
-    expense_id:
-      in: query
-      name: expense_id
-      description: |
-        Expense id for filtering based on expenses.
-        Supported operator is `eq`.
-      schema:
-        type: string
-        example: eq.txS9GZm5hsjh
     id:
       in: query
       name: id
@@ -14720,6 +14711,14 @@ components:
         type: string
         example:
           - eq.ouwruogwnngg
+    expense_id:
+      in: query
+      name: expense_id
+      description: |
+        Expense id for filtering based on expenses. Supported operator is `eq`.
+      schema:
+        type: string
+        example: expense_id=eq.txS9GZm5hsjh
 tags:
   - name: Accounting Exports
     description: |
@@ -19302,49 +19301,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/403'
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/404'
-  /admin/expenses/comments:
-    get:
-      tags:
-        - Expenses
-      summary: List expense comments
-      description: List all the comments of on expense
-      operationId: expense_comments_get
-      parameters:
-        - $ref: '#/components/parameters/expense_id'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    $ref: '#/components/schemas/count'
-                  offset:
-                    $ref: '#/components/schemas/offset'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/expense_comments_out'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400'
-        '401':
-          description: Unauthorised request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/401'
         '404':
           description: Not Found
           content:
@@ -24419,6 +24375,49 @@ paths:
                     $ref: '#/components/schemas/expense_check_mandatory_fields_out'
         '400':
           description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400'
+        '401':
+          description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404'
+  /admin/expenses/comments:
+    get:
+      tags:
+        - Expenses
+      summary: List expense comments
+      description: List all the comments of on expense
+      operationId: expense_comments_get
+      parameters:
+        - $ref: '#/components/parameters/expense_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    $ref: '#/components/schemas/count'
+                  offset:
+                    $ref: '#/components/schemas/offset'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/expense_comments_out'
+        '400':
+          description: Bad request
           content:
             application/json:
               schema:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -6204,6 +6204,73 @@ components:
           $ref: '#/components/schemas/updated_at'
         org_id:
           $ref: '#/components/schemas/id_string'
+    expense_comments_out:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - comment
+        - action
+        - action_data
+        - expense_id
+        - creator_type
+        - creator_user_id
+        - creator_user
+        - org_id
+        - updated_at
+        - created_at
+      properties:
+        id:
+          $ref: '#/components/schemas/id_string'
+        comment:
+          type: string
+          description: comment on the report
+          example: We don't accept laundry bills
+        action:
+          type: string
+          description: Expense action for which comment is added.
+          enum:
+            - ADMIN_APPROVED
+            - APPROVED
+            - APPROVER_REMOVED
+            - AUTO_MATCHED
+            - AUTO_MERGED
+            - COMMENTED
+            - DATA_EXTRACTED
+            - EJECTED_FROM_REPORT
+            - EXPENSE_RULE_APPLIED
+            - FILE_ATTACHED
+            - FILE_DELETED
+            - INVALID_EXPENSE_FIELD_REMOVED
+            - MATCHED
+            - PAID
+            - PARTIALLY_APPROVED
+            - POLICY_RESULT_APPLIED
+            - UNMATCHED
+          example: APPROVED
+        action_data:
+          type: object
+          description: Data related to expense action.
+        expense_id:
+          $ref: '#/components/schemas/id_string'
+        creator_type:
+          type: string
+          description: Describes whether the comment is system-generated or User made.
+          enum:
+            - SYSTEM
+            - POLICY
+            - USER
+          example: USER
+        creator_user_id:
+          $ref: '#/components/schemas/id_string'
+        creator_user:
+          $ref: '#/components/schemas/user_out_embed_nullable'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        org_id:
+          $ref: '#/components/schemas/id_string'
     add_approver_in:
       type: object
       additionalProperties: false
@@ -14635,6 +14702,15 @@ components:
       schema:
         type: string
         example: in.(bacc1234,bacc4567)
+    expense_id:
+      in: query
+      name: expense_id
+      description: |
+        Expense id for filtering based on expenses.
+        Supported operator is `eq`.
+      schema:
+        type: string
+        example: eq.txS9GZm5hsjh
     id:
       in: query
       name: id
@@ -19226,6 +19302,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/403'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404'
+  /admin/expenses/comments:
+    get:
+      tags:
+        - Expenses
+      summary: List expense comments
+      description: List all the comments of on expense
+      operationId: expense_comments_get
+      parameters:
+        - $ref: '#/components/parameters/expense_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    $ref: '#/components/schemas/count'
+                  offset:
+                    $ref: '#/components/schemas/offset'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/expense_comments_out'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400'
+        '401':
+          description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
         '404':
           description: Not Found
           content:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -1711,6 +1711,13 @@ components:
         The unique id of an user to which the object is associated.
       readOnly: true
       example: uswjwgnwwgo
+    user_id_nullable:
+      type: string
+      description: |
+        The unique id of an user to which the object is associated.
+      readOnly: true
+      nullable: true
+      example: uswjwgnwwgo
     user_full_name:
       type: string
       maxLength: 255
@@ -14003,8 +14010,6 @@ components:
         - action_data
         - expense_id
         - creator_type
-        - creator_user_id
-        - creator_user
         - org_id
         - updated_at
         - created_at
@@ -14051,7 +14056,7 @@ components:
             - USER
           example: USER
         creator_user_id:
-          $ref: '#/components/schemas/user_id'
+          $ref: '#/components/schemas/user_id_nullable'
         creator_user:
           $ref: '#/components/schemas/user_out_embed_nullable'
         created_at:

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -2959,73 +2959,6 @@ components:
           $ref: '#/components/schemas/updated_at'
         org_id:
           $ref: '#/components/schemas/id_string'
-    expense_comments_out:
-      type: object
-      additionalProperties: false
-      required:
-        - id
-        - comment
-        - action
-        - action_data
-        - expense_id
-        - creator_type
-        - creator_user_id
-        - creator_user
-        - org_id
-        - updated_at
-        - created_at
-      properties:
-        id:
-          $ref: '#/components/schemas/id_string'
-        comment:
-          type: string
-          description: comment on the report
-          example: We don't accept laundry bills
-        action:
-          type: string
-          description: Expense action for which comment is added.
-          enum:
-            - ADMIN_APPROVED
-            - APPROVED
-            - APPROVER_REMOVED
-            - AUTO_MATCHED
-            - AUTO_MERGED
-            - COMMENTED
-            - DATA_EXTRACTED
-            - EJECTED_FROM_REPORT
-            - EXPENSE_RULE_APPLIED
-            - FILE_ATTACHED
-            - FILE_DELETED
-            - INVALID_EXPENSE_FIELD_REMOVED
-            - MATCHED
-            - PAID
-            - PARTIALLY_APPROVED
-            - POLICY_RESULT_APPLIED
-            - UNMATCHED
-          example: APPROVED
-        action_data:
-          type: object
-          description: Data related to expense action.
-        expense_id:
-          $ref: '#/components/schemas/id_string'
-        creator_type:
-          type: string
-          description: Describes whether the comment is system-generated or User made.
-          enum:
-            - SYSTEM
-            - POLICY
-            - USER
-          example: USER
-        creator_user_id:
-          $ref: '#/components/schemas/id_string'
-        creator_user:
-          $ref: '#/components/schemas/user_out_embed_nullable'
-        created_at:
-          $ref: '#/components/schemas/created_at'
-        updated_at:
-          $ref: '#/components/schemas/updated_at'
-        org_id:
-          $ref: '#/components/schemas/id_string'
     report_permissions_in:
       type: object
       additionalProperties: false
@@ -4009,6 +3942,73 @@ components:
             - 12423
           description: |
             List of IDs of expense fields which are mandatory but are missing.
+    expense_comments_out:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - comment
+        - action
+        - action_data
+        - expense_id
+        - creator_type
+        - creator_user_id
+        - creator_user
+        - org_id
+        - updated_at
+        - created_at
+      properties:
+        id:
+          $ref: '#/components/schemas/id_string'
+        comment:
+          type: string
+          description: comment on the report
+          example: We don't accept laundry bills
+        action:
+          type: string
+          description: Expense action for which comment is added.
+          enum:
+            - ADMIN_APPROVED
+            - APPROVED
+            - APPROVER_REMOVED
+            - AUTO_MATCHED
+            - AUTO_MERGED
+            - COMMENTED
+            - DATA_EXTRACTED
+            - EJECTED_FROM_REPORT
+            - EXPENSE_RULE_APPLIED
+            - FILE_ATTACHED
+            - FILE_DELETED
+            - INVALID_EXPENSE_FIELD_REMOVED
+            - MATCHED
+            - PAID
+            - PARTIALLY_APPROVED
+            - POLICY_RESULT_APPLIED
+            - UNMATCHED
+          example: APPROVED
+        action_data:
+          type: object
+          description: Data related to expense action.
+        expense_id:
+          $ref: '#/components/schemas/id_string'
+        creator_type:
+          type: string
+          description: Describes whether the comment is system-generated or User made.
+          enum:
+            - SYSTEM
+            - POLICY
+            - USER
+          example: USER
+        creator_user_id:
+          $ref: '#/components/schemas/user_id'
+        creator_user:
+          $ref: '#/components/schemas/user_out_embed_nullable'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        org_id:
+          $ref: '#/components/schemas/org_id'
     expense_dismiss_duplicates_in:
       type: object
       required:
@@ -5137,11 +5137,10 @@ components:
       in: query
       name: expense_id
       description: |
-        Expense id for filtering based on expenses.
-        Supported operator is `eq`.
+        Expense id for filtering based on expenses. Supported operator is `eq`.
       schema:
         type: string
-        example: eq.txS9GZm5hsjh
+        example: expense_id=eq.txS9GZm5hsjh
 tags:
   - name: Advances
     description: |
@@ -5994,49 +5993,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/404'
-  /approver/expenses/comments:
-    get:
-      tags:
-        - Expenses
-      summary: List expense comments
-      description: List all the comments of on expense
-      operationId: expense_comments_get
-      parameters:
-        - $ref: '#/components/parameters/expense_id'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    $ref: '#/components/schemas/count'
-                  offset:
-                    $ref: '#/components/schemas/offset'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/expense_comments_out'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400'
-        '401':
-          description: Unauthorised request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/401'
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/404'
   /approver/reports/comments:
     post:
       tags:
@@ -6672,6 +6628,49 @@ paths:
                     $ref: '#/components/schemas/expense_check_mandatory_fields_out'
         '400':
           description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400'
+        '401':
+          description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404'
+  /approver/expenses/comments:
+    get:
+      tags:
+        - Expenses
+      summary: List expense comments
+      description: List all the comments of on expense
+      operationId: expense_comments_get
+      parameters:
+        - $ref: '#/components/parameters/expense_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    $ref: '#/components/schemas/count'
+                  offset:
+                    $ref: '#/components/schemas/offset'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/expense_comments_out'
+        '400':
+          description: Bad request
           content:
             application/json:
               schema:

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -3942,6 +3942,13 @@ components:
             - 12423
           description: |
             List of IDs of expense fields which are mandatory but are missing.
+    user_id_nullable:
+      type: string
+      description: |
+        The unique id of an user to which the object is associated.
+      readOnly: true
+      nullable: true
+      example: uswjwgnwwgo
     expense_comments_out:
       type: object
       additionalProperties: false
@@ -3952,8 +3959,6 @@ components:
         - action_data
         - expense_id
         - creator_type
-        - creator_user_id
-        - creator_user
         - org_id
         - updated_at
         - created_at
@@ -4000,7 +4005,7 @@ components:
             - USER
           example: USER
         creator_user_id:
-          $ref: '#/components/schemas/user_id'
+          $ref: '#/components/schemas/user_id_nullable'
         creator_user:
           $ref: '#/components/schemas/user_out_embed_nullable'
         created_at:

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -2959,6 +2959,73 @@ components:
           $ref: '#/components/schemas/updated_at'
         org_id:
           $ref: '#/components/schemas/id_string'
+    expense_comments_out:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - comment
+        - action
+        - action_data
+        - expense_id
+        - creator_type
+        - creator_user_id
+        - creator_user
+        - org_id
+        - updated_at
+        - created_at
+      properties:
+        id:
+          $ref: '#/components/schemas/id_string'
+        comment:
+          type: string
+          description: comment on the report
+          example: We don't accept laundry bills
+        action:
+          type: string
+          description: Expense action for which comment is added.
+          enum:
+            - ADMIN_APPROVED
+            - APPROVED
+            - APPROVER_REMOVED
+            - AUTO_MATCHED
+            - AUTO_MERGED
+            - COMMENTED
+            - DATA_EXTRACTED
+            - EJECTED_FROM_REPORT
+            - EXPENSE_RULE_APPLIED
+            - FILE_ATTACHED
+            - FILE_DELETED
+            - INVALID_EXPENSE_FIELD_REMOVED
+            - MATCHED
+            - PAID
+            - PARTIALLY_APPROVED
+            - POLICY_RESULT_APPLIED
+            - UNMATCHED
+          example: APPROVED
+        action_data:
+          type: object
+          description: Data related to expense action.
+        expense_id:
+          $ref: '#/components/schemas/id_string'
+        creator_type:
+          type: string
+          description: Describes whether the comment is system-generated or User made.
+          enum:
+            - SYSTEM
+            - POLICY
+            - USER
+          example: USER
+        creator_user_id:
+          $ref: '#/components/schemas/id_string'
+        creator_user:
+          $ref: '#/components/schemas/user_out_embed_nullable'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        org_id:
+          $ref: '#/components/schemas/id_string'
     report_permissions_in:
       type: object
       additionalProperties: false
@@ -5066,6 +5133,15 @@ components:
       schema:
         type: integer
         example: 10
+    expense_id:
+      in: query
+      name: expense_id
+      description: |
+        Expense id for filtering based on expenses.
+        Supported operator is `eq`.
+      schema:
+        type: string
+        example: eq.txS9GZm5hsjh
 tags:
   - name: Advances
     description: |
@@ -5912,6 +5988,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/403'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404'
+  /approver/expenses/comments:
+    get:
+      tags:
+        - Expenses
+      summary: List expense comments
+      description: List all the comments of on expense
+      operationId: expense_comments_get
+      parameters:
+        - $ref: '#/components/parameters/expense_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    $ref: '#/components/schemas/count'
+                  offset:
+                    $ref: '#/components/schemas/offset'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/expense_comments_out'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400'
+        '401':
+          description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
         '404':
           description: Not Found
           content:

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -6655,7 +6655,7 @@ paths:
       tags:
         - Expenses
       summary: List expense comments
-      description: List all the comments of on expense
+      description: List all the comments of an expense
       operationId: expense_comments_get
       parameters:
         - $ref: '#/components/parameters/expense_id'

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -167,12 +167,6 @@ components:
         The unique id of an user to which the object is associated.
       readOnly: true
       example: uswjwgnwwgo
-    user_id_nullable:
-      type: string
-      description: |
-        The unique id of an user to which the object is associated.
-      readOnly: true
-      example: uswjwgnwwgo
     org_name:
       type: string
       maxLength: 255

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -167,6 +167,12 @@ components:
         The unique id of an user to which the object is associated.
       readOnly: true
       example: uswjwgnwwgo
+    user_id_nullable:
+      type: string
+      description: |
+        The unique id of an user to which the object is associated.
+      readOnly: true
+      example: uswjwgnwwgo
     org_name:
       type: string
       maxLength: 255
@@ -3994,6 +4000,7 @@ components:
         action_data:
           type: object
           description: Data related to expense action.
+          nullable: true
         expense_id:
           $ref: '#/components/schemas/id_string'
         creator_type:

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -3694,73 +3694,6 @@ components:
           $ref: '#/components/schemas/updated_at'
         org_id:
           $ref: '#/components/schemas/id_string'
-    expense_comments_out:
-      type: object
-      additionalProperties: false
-      required:
-        - id
-        - comment
-        - action
-        - action_data
-        - expense_id
-        - creator_type
-        - creator_user_id
-        - creator_user
-        - org_id
-        - updated_at
-        - created_at
-      properties:
-        id:
-          $ref: '#/components/schemas/id_string'
-        comment:
-          type: string
-          description: comment on the report
-          example: We don't accept laundry bills
-        action:
-          type: string
-          description: Expense action for which comment is added.
-          enum:
-            - ADMIN_APPROVED
-            - APPROVED
-            - APPROVER_REMOVED
-            - AUTO_MATCHED
-            - AUTO_MERGED
-            - COMMENTED
-            - DATA_EXTRACTED
-            - EJECTED_FROM_REPORT
-            - EXPENSE_RULE_APPLIED
-            - FILE_ATTACHED
-            - FILE_DELETED
-            - INVALID_EXPENSE_FIELD_REMOVED
-            - MATCHED
-            - PAID
-            - PARTIALLY_APPROVED
-            - POLICY_RESULT_APPLIED
-            - UNMATCHED
-          example: APPROVED
-        action_data:
-          type: object
-          description: Data related to expense action.
-        expense_id:
-          $ref: '#/components/schemas/id_string'
-        creator_type:
-          type: string
-          description: Describes whether the comment is system-generated or User made.
-          enum:
-            - SYSTEM
-            - POLICY
-            - USER
-          example: USER
-        creator_user_id:
-          $ref: '#/components/schemas/id_string'
-        creator_user:
-          $ref: '#/components/schemas/user_out_embed_nullable'
-        created_at:
-          $ref: '#/components/schemas/created_at'
-        updated_at:
-          $ref: '#/components/schemas/updated_at'
-        org_id:
-          $ref: '#/components/schemas/id_string'
     report_permissions_in:
       type: object
       additionalProperties: false
@@ -8479,6 +8412,73 @@ components:
               - 12423
             description: |
               List of IDs of expense fields which are mandatory but are missing.
+    expense_comments_out:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - comment
+        - action
+        - action_data
+        - expense_id
+        - creator_type
+        - creator_user_id
+        - creator_user
+        - org_id
+        - updated_at
+        - created_at
+      properties:
+        id:
+          $ref: '#/components/schemas/id_string'
+        comment:
+          type: string
+          description: comment on the report
+          example: We don't accept laundry bills
+        action:
+          type: string
+          description: Expense action for which comment is added.
+          enum:
+            - ADMIN_APPROVED
+            - APPROVED
+            - APPROVER_REMOVED
+            - AUTO_MATCHED
+            - AUTO_MERGED
+            - COMMENTED
+            - DATA_EXTRACTED
+            - EJECTED_FROM_REPORT
+            - EXPENSE_RULE_APPLIED
+            - FILE_ATTACHED
+            - FILE_DELETED
+            - INVALID_EXPENSE_FIELD_REMOVED
+            - MATCHED
+            - PAID
+            - PARTIALLY_APPROVED
+            - POLICY_RESULT_APPLIED
+            - UNMATCHED
+          example: APPROVED
+        action_data:
+          type: object
+          description: Data related to expense action.
+        expense_id:
+          $ref: '#/components/schemas/id_string'
+        creator_type:
+          type: string
+          description: Describes whether the comment is system-generated or User made.
+          enum:
+            - SYSTEM
+            - POLICY
+            - USER
+          example: USER
+        creator_user_id:
+          $ref: '#/components/schemas/user_id'
+        creator_user:
+          $ref: '#/components/schemas/user_out_embed_nullable'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        org_id:
+          $ref: '#/components/schemas/org_id'
     expense_dismiss_duplicates_in:
       type: object
       required:
@@ -9441,11 +9441,10 @@ components:
       in: query
       name: expense_id
       description: |
-        Expense id for filtering based on expenses.
-        Supported operator is `eq`.
+        Expense id for filtering based on expenses. Supported operator is `eq`.
       schema:
         type: string
-        example: eq.txS9GZm5hsjh
+        example: expense_id=eq.txS9GZm5hsjh
 tags:
   - name: Accounts
     description: |

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -393,6 +393,12 @@ components:
         The unique id of an user to which the object is associated.
       readOnly: true
       example: uswjwgnwwgo
+    user_id_nullable:
+      type: string
+      description: |
+        The unique id of an user to which the object is associated.
+      readOnly: true
+      example: uswjwgnwwgo
     currency:
       type: string
       description: |
@@ -8464,6 +8470,7 @@ components:
         action_data:
           type: object
           description: Data related to expense action.
+          nullable: true
         expense_id:
           $ref: '#/components/schemas/id_string'
         creator_type:

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -8412,6 +8412,13 @@ components:
               - 12423
             description: |
               List of IDs of expense fields which are mandatory but are missing.
+    user_id_nullable:
+      type: string
+      description: |
+        The unique id of an user to which the object is associated.
+      readOnly: true
+      nullable: true
+      example: uswjwgnwwgo
     expense_comments_out:
       type: object
       additionalProperties: false
@@ -8422,8 +8429,6 @@ components:
         - action_data
         - expense_id
         - creator_type
-        - creator_user_id
-        - creator_user
         - org_id
         - updated_at
         - created_at
@@ -8470,7 +8475,7 @@ components:
             - USER
           example: USER
         creator_user_id:
-          $ref: '#/components/schemas/user_id'
+          $ref: '#/components/schemas/user_id_nullable'
         creator_user:
           $ref: '#/components/schemas/user_out_embed_nullable'
         created_at:

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -3694,6 +3694,73 @@ components:
           $ref: '#/components/schemas/updated_at'
         org_id:
           $ref: '#/components/schemas/id_string'
+    expense_comments_out:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - comment
+        - action
+        - action_data
+        - expense_id
+        - creator_type
+        - creator_user_id
+        - creator_user
+        - org_id
+        - updated_at
+        - created_at
+      properties:
+        id:
+          $ref: '#/components/schemas/id_string'
+        comment:
+          type: string
+          description: comment on the report
+          example: We don't accept laundry bills
+        action:
+          type: string
+          description: Expense action for which comment is added.
+          enum:
+            - ADMIN_APPROVED
+            - APPROVED
+            - APPROVER_REMOVED
+            - AUTO_MATCHED
+            - AUTO_MERGED
+            - COMMENTED
+            - DATA_EXTRACTED
+            - EJECTED_FROM_REPORT
+            - EXPENSE_RULE_APPLIED
+            - FILE_ATTACHED
+            - FILE_DELETED
+            - INVALID_EXPENSE_FIELD_REMOVED
+            - MATCHED
+            - PAID
+            - PARTIALLY_APPROVED
+            - POLICY_RESULT_APPLIED
+            - UNMATCHED
+          example: APPROVED
+        action_data:
+          type: object
+          description: Data related to expense action.
+        expense_id:
+          $ref: '#/components/schemas/id_string'
+        creator_type:
+          type: string
+          description: Describes whether the comment is system-generated or User made.
+          enum:
+            - SYSTEM
+            - POLICY
+            - USER
+          example: USER
+        creator_user_id:
+          $ref: '#/components/schemas/id_string'
+        creator_user:
+          $ref: '#/components/schemas/user_out_embed_nullable'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        org_id:
+          $ref: '#/components/schemas/id_string'
     report_permissions_in:
       type: object
       additionalProperties: false
@@ -9370,6 +9437,15 @@ components:
       schema:
         type: string
         example: updated_at.desc,id
+    expense_id:
+      in: query
+      name: expense_id
+      description: |
+        Expense id for filtering based on expenses.
+        Supported operator is `eq`.
+      schema:
+        type: string
+        example: eq.txS9GZm5hsjh
 tags:
   - name: Accounts
     description: |
@@ -13286,6 +13362,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/403'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404'
+  /spender/expenses/comments:
+    get:
+      tags:
+        - Expenses
+      summary: List expense comments
+      description: List all the comments of on expense
+      operationId: expense_comments_get
+      parameters:
+        - $ref: '#/components/parameters/expense_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    $ref: '#/components/schemas/count'
+                  offset:
+                    $ref: '#/components/schemas/offset'
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/expense_comments_out'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400'
+        '401':
+          description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
         '404':
           description: Not Found
           content:

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -393,12 +393,6 @@ components:
         The unique id of an user to which the object is associated.
       readOnly: true
       example: uswjwgnwwgo
-    user_id_nullable:
-      type: string
-      description: |
-        The unique id of an user to which the object is associated.
-      readOnly: true
-      example: uswjwgnwwgo
     currency:
       type: string
       description: |

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -13378,7 +13378,7 @@ paths:
       tags:
         - Expenses
       summary: List expense comments
-      description: List all the comments of on expense
+      description: List all the comments of an expense
       operationId: expense_comments_get
       parameters:
         - $ref: '#/components/parameters/expense_id'

--- a/src/admin/openapi.yaml
+++ b/src/admin/openapi.yaml
@@ -448,6 +448,8 @@ paths:
     $ref: paths/admin@expense_rules@delete.yaml
   /admin/expenses/check_mandatory_fields:
     $ref: paths/admin@expenses@check_mandatory_fields.yaml
+  /admin/expenses/comments:
+    $ref: paths/admin@expenses@comments.yaml
   /admin/expenses/dismiss_duplicates/bulk:
     $ref: paths/admin@expenses@dismiss_duplicates@bulk.yaml
   /admin/expenses/duplicate_sets:

--- a/src/admin/paths/admin@expenses@comments.yaml
+++ b/src/admin/paths/admin@expenses@comments.yaml
@@ -2,7 +2,7 @@ get:
   tags:
     - Expenses
   summary: List expense comments
-  description: List all the comments of on expense
+  description: List all the comments of an expense
   operationId: expense_comments_get
   parameters:
     - $ref: '../../components/parameters/expense_id.yaml'

--- a/src/admin/paths/admin@expenses@comments.yaml
+++ b/src/admin/paths/admin@expenses@comments.yaml
@@ -1,0 +1,42 @@
+get:
+  tags:
+    - Expenses
+  summary: List expense comments
+  description: List all the comments of on expense
+  operationId: expense_comments_get
+  parameters:
+    - $ref: '../../components/parameters/expense_id.yaml'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                $ref: '../../components/schemas/count.yaml'
+              offset:
+                $ref: '../../components/schemas/offset.yaml'
+              data:
+                type: array
+                items:
+                  $ref: '../../components/schemas/expense.yaml#/expense_comments_out'
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/400.yaml'
+    '401':
+      description: Unauthorised request
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/401.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/404.yaml'

--- a/src/approver/openapi.yaml
+++ b/src/approver/openapi.yaml
@@ -122,6 +122,8 @@ paths:
     $ref: paths/approver@expense_policies@states.yaml
   /approver/expenses/check_mandatory_fields:
     $ref: paths/approver@expenses@check_mandatory_fields.yaml
+  /approver/expenses/comments:
+    $ref: paths/approver@expenses@comments.yaml
   /approver/expenses/dismiss_duplicates/bulk:
     $ref: paths/approver@expenses@dismiss_duplicates@bulk.yaml
   /approver/expenses/duplicate_sets:

--- a/src/approver/paths/approver@expenses@comments.yaml
+++ b/src/approver/paths/approver@expenses@comments.yaml
@@ -2,7 +2,7 @@ get:
   tags:
     - Expenses
   summary: List expense comments
-  description: List all the comments of on expense
+  description: List all the comments of an expense
   operationId: expense_comments_get
   parameters:
     - $ref: '../../components/parameters/expense_id.yaml'

--- a/src/approver/paths/approver@expenses@comments.yaml
+++ b/src/approver/paths/approver@expenses@comments.yaml
@@ -1,0 +1,42 @@
+get:
+  tags:
+    - Expenses
+  summary: List expense comments
+  description: List all the comments of on expense
+  operationId: expense_comments_get
+  parameters:
+    - $ref: '../../components/parameters/expense_id.yaml'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                $ref: '../../components/schemas/count.yaml'
+              offset:
+                $ref: '../../components/schemas/offset.yaml'
+              data:
+                type: array
+                items:
+                  $ref: '../../components/schemas/expense.yaml#/expense_comments_out'
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/400.yaml'
+    '401':
+      description: Unauthorised request
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/401.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/404.yaml'

--- a/src/components/parameters/expense_id.yaml
+++ b/src/components/parameters/expense_id.yaml
@@ -1,0 +1,9 @@
+in: query
+name: expense_id
+description: >
+    Expense id for filtering based on expenses.
+    Supported operator is `eq`.
+schema:
+  type: string
+  example: >-
+    expense_id=eq.txS9GZm5hsjh

--- a/src/components/schemas/expense.yaml
+++ b/src/components/schemas/expense.yaml
@@ -2141,8 +2141,6 @@ expense_comments_out:
     - action_data
     - expense_id
     - creator_type
-    - creator_user_id
-    - creator_user
     - org_id
     - updated_at
     - created_at
@@ -2189,7 +2187,7 @@ expense_comments_out:
         - USER
       example: USER
     creator_user_id:
-      $ref: './fields.yaml#/user_id'
+      $ref: './fields.yaml#/user_id_nullable'
     creator_user:
       $ref:  './user.yaml#/user_out_embed_nullable'
     created_at:

--- a/src/components/schemas/expense.yaml
+++ b/src/components/schemas/expense.yaml
@@ -2130,7 +2130,75 @@ expense_check_mandatory_fields_in:
       $ref: './fields.yaml#/claim_amount'
   allOf:
     - $ref: ./expense.yaml#/spender_expense_check_mandatory_fields_in
-    
+
+expense_comments_out:
+  type: object
+  additionalProperties: false
+  required:
+    - id
+    - comment
+    - action
+    - action_data
+    - expense_id
+    - creator_type
+    - creator_user_id
+    - creator_user
+    - org_id
+    - updated_at
+    - created_at
+  properties:
+    id:
+      $ref: './fields.yaml#/id_string'
+    comment:
+      type: string
+      description: comment on the report
+      example: We don't accept laundry bills
+    action:
+      type: string
+      description: Expense action for which comment is added.
+      enum:
+        - ADMIN_APPROVED
+        - APPROVED
+        - APPROVER_REMOVED
+        - AUTO_MATCHED
+        - AUTO_MERGED
+        - COMMENTED
+        - DATA_EXTRACTED
+        - EJECTED_FROM_REPORT
+        - EXPENSE_RULE_APPLIED
+        - FILE_ATTACHED
+        - FILE_DELETED
+        - INVALID_EXPENSE_FIELD_REMOVED
+        - MATCHED
+        - PAID
+        - PARTIALLY_APPROVED
+        - POLICY_RESULT_APPLIED
+        - UNMATCHED
+      example: APPROVED
+    action_data:
+      type: object
+      description: Data related to expense action.
+    expense_id:
+      $ref: './fields.yaml#/id_string'
+    creator_type:
+      type: string
+      description: Describes whether the comment is system-generated or User made.
+      enum:
+        - SYSTEM
+        - POLICY
+        - USER
+      example: USER
+    creator_user_id:
+      $ref: './fields.yaml#/user_id'
+    creator_user:
+      $ref:  './user.yaml#/user_out_embed_nullable'
+    created_at:
+      $ref: './fields.yaml#/created_at'
+    updated_at:
+      $ref: './fields.yaml#/updated_at'
+    org_id:
+      $ref: './fields.yaml#/org_id'
+
 expense_dismiss_duplicates_in:
   type: object
   required:

--- a/src/components/schemas/expense.yaml
+++ b/src/components/schemas/expense.yaml
@@ -2176,6 +2176,7 @@ expense_comments_out:
     action_data:
       type: object
       description: Data related to expense action.
+      nullable: true
     expense_id:
       $ref: './fields.yaml#/id_string'
     creator_type:

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -69,6 +69,14 @@ user_id:
   readOnly: true
   example: uswjwgnwwgo
 
+user_id_nullable:
+  type: string
+  description: |
+    The unique id of an user to which the object is associated.
+  readOnly: true
+  nullable: true
+  example: uswjwgnwwgo
+
 timestamptz_utc:
   type: string
   format: date-time

--- a/src/spender/openapi.yaml
+++ b/src/spender/openapi.yaml
@@ -260,6 +260,8 @@ paths:
     $ref: paths/spender@expenses@check_mandatory_fields.yaml
   /spender/expenses/check_mandatory_fields/bulk:
     $ref: paths/spender@expenses@check_mandatory_fields_bulk.yaml
+  /spender/expenses/comments:
+    $ref: paths/spender@expenses@comments.yaml
   /spender/expenses/dismiss_duplicates/bulk:
     $ref: paths/spender@expenses@dismiss_duplicates@bulk.yaml
   /spender/expenses/duplicate_sets:

--- a/src/spender/paths/spender@expenses@comments.yaml
+++ b/src/spender/paths/spender@expenses@comments.yaml
@@ -2,7 +2,7 @@ get:
   tags:
     - Expenses
   summary: List expense comments
-  description: List all the comments of on expense
+  description: List all the comments of an expense
   operationId: expense_comments_get
   parameters:
     - $ref: '../../components/parameters/expense_id.yaml'

--- a/src/spender/paths/spender@expenses@comments.yaml
+++ b/src/spender/paths/spender@expenses@comments.yaml
@@ -1,0 +1,42 @@
+get:
+  tags:
+    - Expenses
+  summary: List expense comments
+  description: List all the comments of on expense
+  operationId: expense_comments_get
+  parameters:
+    - $ref: '../../components/parameters/expense_id.yaml'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                $ref: '../../components/schemas/count.yaml'
+              offset:
+                $ref: '../../components/schemas/offset.yaml'
+              data:
+                type: array
+                items:
+                  $ref: '../../components/schemas/expense.yaml#/expense_comments_out'
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/400.yaml'
+    '401':
+      description: Unauthorised request
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/401.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/404.yaml'


### PR DESCRIPTION
### Screenshot

- GET admin/expenses/comments

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/a85b882f-d766-417e-a338-2560855dc0c4" />
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/1c051cfc-69f8-443c-adf7-cf26df2a8c7d" />

- GET approver/expenses/comments
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/93dea278-8452-43f0-a2d6-b48adae00d95" />
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/3fdec14c-12b8-4c49-9972-e49fb1012dc2" />
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/b6e31373-c70a-4300-b81d-b89e83c6ad52" />

- GET spender/expenses/comments

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/11551b26-18ad-4456-8390-ae4b18b8142b" />
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/9ca70375-b120-4a3b-aa75-d795e6afe8e6" />
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/d997de74-b298-413f-a81d-2f12349df71e" />


## Clickup
https://app.clickup.com/t/86cy1e3pr