### PR TITLE
feat: update API docs for /admin/reminders to show examples of cron format

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -6159,7 +6159,7 @@ components:
                   example: mon
                   description: Single weekday name (e.g. "mon")
                 - type: string
-                  pattern: '^[1-7](?:,[1-7])*$'
+                  pattern: ^[1-7](?:,[1-7])*$
                   example: 1,3,5
                   description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
             hour:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -6129,6 +6129,10 @@ components:
           type: object
           additionalProperties: false
           properties:
+            year:
+              type: string
+              example: '*'
+              description: cron expression (string, e.g. "*" for every year)
             month:
               oneOf:
                 - type: number
@@ -6163,21 +6167,13 @@ components:
                   example: 1,3,5
                   description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
             hour:
-              oneOf:
-                - type: number
-                  example: 22
-                  description: hour of the day in 24-hr format (0-23)
-                - type: string
-                  example: '*/2'
-                  description: cron expression (e.g. "*/2" for every 2 hours)
+              type: number
+              example: 22
+              description: hour of the day in 24-hr format (0-23)
             minute:
-              oneOf:
-                - type: number
-                  example: 42
-                  description: minute of the hour (0-59)
-                - type: string
-                  example: '*/15'
-                  description: cron expression (e.g. "*/15" for every 15 minutes)
+              type: number
+              example: 42
+              description: minute of the hour (0-59)
     reminder_receiver_user_ids:
       type: array
       nullable: true

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -6126,16 +6126,28 @@ components:
           enum:
             - cron
         when:
-          oneOf:
-            - type: object
-              additionalProperties: false
-              properties:
-                day:
-                  type: number
+          type: object
+          additionalProperties: false
+          properties:
+            month:
+              oneOf:
+                - type: number
+                  example: 1
+                  description: Month of the year (number, e.g. 1)
+                - type: string
+                  example: '*/2'
+                  description: cron expression (e.g. '*/2' for every alternate month)
+            day:
+              oneOf:
+                - type: number
                   example: 15
                   description: Day of month (number, e.g. 15)
-                day_of_week:
-                  type: string
+                - type: string
+                  example: last
+                  description: cron expression (string, e.g. "last")
+            day_of_week:
+              oneOf:
+                - type: string
                   enum:
                     - mon
                     - tue
@@ -6146,31 +6158,24 @@ components:
                     - sun
                   example: mon
                   description: Single weekday name (e.g. "mon")
-                hour:
-                  type: number
-                  example: 22
-                  description: hour of the day in 24-hr format (0-23)
-                minute:
-                  type: number
-                  example: 42
-                  description: minute of the hour (0-59)
-            - type: object
-              additionalProperties: false
-              properties:
-                day:
-                  type: string
-                  example: last
-                  description: cron expression (string, e.g. "last")
-                day_of_week:
-                  type: string
+                - type: string
+                  pattern: '^[1-7](?:,[1-7])*$'
                   example: 1,3,5
                   description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
-                hour:
-                  type: string
+            hour:
+              oneOf:
+                - type: number
+                  example: 22
+                  description: hour of the day in 24-hr format (0-23)
+                - type: string
                   example: '*/2'
                   description: cron expression (e.g. "*/2" for every 2 hours)
-                minute:
-                  type: string
+            minute:
+              oneOf:
+                - type: number
+                  example: 42
+                  description: minute of the hour (0-59)
+                - type: string
                   example: '*/15'
                   description: cron expression (e.g. "*/15" for every 15 minutes)
     reminder_receiver_user_ids:

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -6126,34 +6126,53 @@ components:
           enum:
             - cron
         when:
-          nullable: false
-          type: object
-          additionalProperties: false
-          properties:
-            day:
-              type: number
-              description: day of month (1-31)
-              example: 16
-            day_of_week:
-              type: string
-              enum:
-                - mon
-                - tue
-                - wed
-                - thu
-                - fri
-                - sat
-                - sun
-              description: name of weekday
-              example: mon
-            hour:
-              type: number
-              example: 22
-              description: hour of the day in 24-hr format (0-23)
-            minute:
-              type: number
-              example: 42
-              description: minute of the hour
+          oneOf:
+            - type: object
+              additionalProperties: false
+              properties:
+                day:
+                  type: number
+                  example: 15
+                  description: Day of month (number, e.g. 15)
+                day_of_week:
+                  type: string
+                  enum:
+                    - mon
+                    - tue
+                    - wed
+                    - thu
+                    - fri
+                    - sat
+                    - sun
+                  example: mon
+                  description: Single weekday name (e.g. "mon")
+                hour:
+                  type: number
+                  example: 22
+                  description: hour of the day in 24-hr format (0-23)
+                minute:
+                  type: number
+                  example: 42
+                  description: minute of the hour (0-59)
+            - type: object
+              additionalProperties: false
+              properties:
+                day:
+                  type: string
+                  example: "last"
+                  description: cron expression (string, e.g. "last")
+                day_of_week:
+                  type: string
+                  example: "1,3,5"
+                  description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
+                hour:
+                  type: string
+                  example: "*/2"
+                  description: cron expression (e.g. "*/2" for every 2 hours)
+                minute:
+                  type: string
+                  example: "*/15"
+                  description: cron expression (e.g. "*/15" for every 15 minutes)
     reminder_receiver_user_ids:
       type: array
       nullable: true

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -6159,19 +6159,19 @@ components:
               properties:
                 day:
                   type: string
-                  example: "last"
+                  example: last
                   description: cron expression (string, e.g. "last")
                 day_of_week:
                   type: string
-                  example: "1,3,5"
+                  example: 1,3,5
                   description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
                 hour:
                   type: string
-                  example: "*/2"
+                  example: '*/2'
                   description: cron expression (e.g. "*/2" for every 2 hours)
                 minute:
                   type: string
-                  example: "*/15"
+                  example: '*/15'
                   description: cron expression (e.g. "*/15" for every 15 minutes)
     reminder_receiver_user_ids:
       type: array

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -1292,6 +1292,10 @@ reminder_schedule_config:
       type: object
       additionalProperties: false
       properties:
+        year:
+          type: string
+          example: '*'
+          description: cron expression (string, e.g. "*" for every year)
         month:
           oneOf:
             - type: number
@@ -1326,21 +1330,13 @@ reminder_schedule_config:
               example: 1,3,5
               description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
         hour:
-          oneOf:
-            - type: number
-              example: 22
-              description: hour of the day in 24-hr format (0-23)
-            - type: string
-              example: '*/2'
-              description: cron expression (e.g. "*/2" for every 2 hours)
+          type: number
+          example: 22
+          description: hour of the day in 24-hr format (0-23)
         minute:
-          oneOf:
-            - type: number
-              example: 42
-              description: minute of the hour (0-59)
-            - type: string
-              example: '*/15'
-              description: cron expression (e.g. "*/15" for every 15 minutes)
+          type: number
+          example: 42
+          description: minute of the hour (0-59)
 project_display_name:
   type: string
   nullable: false

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -1289,35 +1289,53 @@ reminder_schedule_config:
       enum:
         - cron
     when:
-      nullable: false
-      type: object
-      additionalProperties: false
-      properties:
-        day:
-          type: number
-          description: day of month (1-31)
-          example: 16
-        day_of_week:
-          type: string
-          enum:
-            - mon
-            - tue
-            - wed
-            - thu
-            - fri
-            - sat
-            - sun
-          description: name of weekday
-          example: mon
-        hour:
-          type: number
-          example: 22
-          description: hour of the day in 24-hr format (0-23)
-        minute:
-          type: number
-          example: 42
-          description: minute of the hour
-
+      oneOf:
+        - type: object
+          additionalProperties: false
+          properties:
+            day:
+              type: number
+              example: 15
+              description: Day of month (number, e.g. 15)
+            day_of_week:
+              type: string
+              enum:
+                - mon
+                - tue
+                - wed
+                - thu
+                - fri
+                - sat
+                - sun
+              example: mon
+              description: Single weekday name (e.g. "mon")
+            hour:
+              type: number
+              example: 22
+              description: hour of the day in 24-hr format (0-23)
+            minute:
+              type: number
+              example: 42
+              description: minute of the hour (0-59)
+        - type: object
+          additionalProperties: false
+          properties:
+            day:
+              type: string
+              example: "last"
+              description: cron expression (string, e.g. "last")
+            day_of_week:
+              type: string
+              example: "1,3,5"
+              description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
+            hour:
+              type: string
+              example: "*/2"
+              description: cron expression (e.g. "*/2" for every 2 hours)
+            minute:
+              type: string
+              example: "*/15"
+              description: cron expression (e.g. "*/15" for every 15 minutes)
 project_display_name:
   type: string
   nullable: false

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -1289,16 +1289,28 @@ reminder_schedule_config:
       enum:
         - cron
     when:
-      oneOf:
-        - type: object
-          additionalProperties: false
-          properties:
-            day:
-              type: number
+      type: object
+      additionalProperties: false
+      properties:
+        month:
+          oneOf:
+            - type: number
+              example: 1
+              description: Month of the year (number, e.g. 1)
+            - type: string
+              example: '*/2'
+              description: cron expression (e.g. '*/2' for every alternate month)
+        day:
+          oneOf:
+            - type: number
               example: 15
               description: Day of month (number, e.g. 15)
-            day_of_week:
-              type: string
+            - type: string
+              example: last
+              description: cron expression (string, e.g. "last")
+        day_of_week:
+          oneOf:
+            - type: string
               enum:
                 - mon
                 - tue
@@ -1309,32 +1321,25 @@ reminder_schedule_config:
                 - sun
               example: mon
               description: Single weekday name (e.g. "mon")
-            hour:
-              type: number
+            - type: string
+              pattern: '^[1-7](?:,[1-7])*$'
+              example: 1,3,5
+              description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
+        hour:
+          oneOf:
+            - type: number
               example: 22
               description: hour of the day in 24-hr format (0-23)
-            minute:
-              type: number
+            - type: string
+              example: '*/2'
+              description: cron expression (e.g. "*/2" for every 2 hours)
+        minute:
+          oneOf:
+            - type: number
               example: 42
               description: minute of the hour (0-59)
-        - type: object
-          additionalProperties: false
-          properties:
-            day:
-              type: string
-              example: "last"
-              description: cron expression (string, e.g. "last")
-            day_of_week:
-              type: string
-              example: "1,3,5"
-              description: comma-separated day numbers (e.g. "1,3,5" for mon,wed,fri)
-            hour:
-              type: string
-              example: "*/2"
-              description: cron expression (e.g. "*/2" for every 2 hours)
-            minute:
-              type: string
-              example: "*/15"
+            - type: string
+              example: '*/15'
               description: cron expression (e.g. "*/15" for every 15 minutes)
 project_display_name:
   type: string


### PR DESCRIPTION
### Description
/admin/reminders API already supports cron format for recurring reminders, this PR updates the API docs to reflect this

## Clickup
https://app.clickup.com/t/86czjngaa