### PR TITLE
feat: Added changes in API documentation for supported policy_violation_reason_required field

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -17975,6 +17975,9 @@ components:
           example: epc1a2f3farmk
         comment_type:
           type: string
+          enum:
+            - LOST_RECEIPT_REASON
+            - POLICY_VIOLATION_REASON
           description: Type of the policy comment
         comment_text:
           type: string
@@ -28179,6 +28182,12 @@ components:
             If it is set to true, then a warning is shown to the employee, whenever he attempts to create an expense that violates this policy rule.
           default: false
           example: true
+        policy_violation_reason_required:
+          type: boolean
+          description: |
+            If it is set to true, then entering a policy violation reason becomes mandatory for expenses violating this policy rule.
+          default: false
+          example: false
         action_make_unreportable:
           type: boolean
           description: |
@@ -28295,6 +28304,7 @@ components:
             - employee_titles_op
             - action_flag
             - action_show_warning
+            - policy_violation_reason_required
             - action_make_unreportable
             - description
           default: true
@@ -28638,6 +28648,13 @@ components:
             If it is set to true, then a warning is shown to the employee, whenever he attempts to create an expense that violates this policy rule.
           default: false
           example: true
+        policy_violation_reason_required:
+          type: boolean
+          description: |
+            If it is set to true, then entering a policy violation reason becomes mandatory for expenses violating this policy rule. <br>
+            _Note: This can be true only when `action_show_warning` is true._
+          default: false
+          example: false
         action_make_unreportable:
           type: boolean
           description: |

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -28733,6 +28733,11 @@ components:
           description: |
             A true value here means that policy calculation suggests showing a warning when the user attempts to create an expense that violates this expense policy rule.
           example: true
+        policy_violation_reason_required:
+          type: boolean
+          description: |
+            A true value here means that entering a policy violation reason is mandatory for this policy rule.
+          example: false
         action_make_unreportable:
           type: boolean
           nullable: false

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -8371,6 +8371,11 @@ components:
           description: |
             A true value here means that policy calculation suggests showing a warning when the user attempts to create an expense that violates this expense policy rule.
           example: true
+        policy_violation_reason_required:
+          type: boolean
+          description: |
+            A true value here means that entering a policy violation reason is mandatory for this policy rule.
+          example: false
         action_make_unreportable:
           type: boolean
           nullable: false

--- a/reference/approver.yaml
+++ b/reference/approver.yaml
@@ -5521,6 +5521,9 @@ components:
           example: epc1a2f3farmk
         comment_type:
           type: string
+          enum:
+            - LOST_RECEIPT_REASON
+            - POLICY_VIOLATION_REASON
           description: Type of the policy comment
         comment_text:
           type: string

--- a/reference/manager.yaml
+++ b/reference/manager.yaml
@@ -843,6 +843,11 @@ components:
           description: |
             A true value here means that policy calculation suggests showing a warning when the user attempts to create an expense that violates this expense policy rule.
           example: true
+        policy_violation_reason_required:
+          type: boolean
+          description: |
+            A true value here means that entering a policy violation reason is mandatory for this policy rule.
+          example: false
         action_make_unreportable:
           type: boolean
           nullable: false
@@ -2209,6 +2214,9 @@ components:
           example: epc1a2f3farmk
         comment_type:
           type: string
+          enum:
+            - LOST_RECEIPT_REASON
+            - POLICY_VIOLATION_REASON
           description: Type of the policy comment
         comment_text:
           type: string

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -8719,6 +8719,9 @@ components:
           example: epc1a2f3farmk
         comment_type:
           type: string
+          enum:
+            - LOST_RECEIPT_REASON
+            - POLICY_VIOLATION_REASON
           description: Type of the policy comment
         comment_text:
           type: string
@@ -16484,6 +16487,12 @@ components:
             If it is set to true, then a warning is shown to the employee, whenever he attempts to create an expense that violates this policy rule.
           default: false
           example: true
+        policy_violation_reason_required:
+          type: boolean
+          description: |
+            If it is set to true, then entering a policy violation reason becomes mandatory for expenses violating this policy rule.
+          default: false
+          example: false
         action_make_unreportable:
           type: boolean
           description: |
@@ -16572,6 +16581,11 @@ components:
           description: |
             A true value here means that policy calculation suggests showing a warning when the user attempts to create an expense that violates this expense policy rule.
           example: true
+        policy_violation_reason_required:
+          type: boolean
+          description: |
+            A true value here means that entering a policy violation reason is mandatory for this policy rule.
+          example: false
         action_make_unreportable:
           type: boolean
           nullable: false

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -16828,8 +16828,6 @@ components:
             _Note: This field is mandatory when you are creating an expense and want to check it against the policy rules before saving the expense._
         source:
           $ref: '#/components/schemas/source'
-        currency:
-          $ref: '#/components/schemas/currency'
         merchant:
           $ref: '#/components/schemas/merchant'
         foreign_currency:

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -16828,6 +16828,8 @@ components:
             _Note: This field is mandatory when you are creating an expense and want to check it against the policy rules before saving the expense._
         source:
           $ref: '#/components/schemas/source'
+        currency:
+          $ref: '#/components/schemas/currency'
         merchant:
           $ref: '#/components/schemas/merchant'
         foreign_currency:

--- a/src/components/schemas/expense.yaml
+++ b/src/components/schemas/expense.yaml
@@ -2970,6 +2970,9 @@ expense_policy_comment_out_embed:
       example: epc1a2f3farmk
     comment_type:
       type: string
+      enum:
+        - LOST_RECEIPT_REASON
+        - POLICY_VIOLATION_REASON
       description: Type of the policy comment
     comment_text:
       type: string

--- a/src/components/schemas/expense_policies.yaml
+++ b/src/components/schemas/expense_policies.yaml
@@ -45,6 +45,7 @@ expense_policy_in:
         - employee_titles_op
         - action_flag
         - action_show_warning
+        - policy_violation_reason_required
         - action_make_unreportable
         - description
       default: True
@@ -374,6 +375,13 @@ expense_policy_in:
         If it is set to true, then a warning is shown to the employee, whenever he attempts to create an expense that violates this policy rule.
       default: False
       example: True
+    policy_violation_reason_required:
+      type: boolean
+      description: |
+        If it is set to true, then entering a policy violation reason becomes mandatory for expenses violating this policy rule. <br>
+        _Note: This can be true only when `action_show_warning` is true._
+      default: False
+      example: False
     action_make_unreportable:
       type: boolean
       description: |
@@ -789,6 +797,12 @@ expense_policy_out:
         If it is set to true, then a warning is shown to the employee, whenever he attempts to create an expense that violates this policy rule.
       default: False
       example: True
+    policy_violation_reason_required:
+      type: boolean
+      description: |
+        If it is set to true, then entering a policy violation reason becomes mandatory for expenses violating this policy rule.
+      default: False
+      example: False
     action_make_unreportable:
       type: boolean
       description: |

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -374,6 +374,11 @@ expense_policy_rule_embed:
       description: |
         A true value here means that policy calculation suggests showing a warning when the user attempts to create an expense that violates this expense policy rule.
       example: True
+    policy_violation_reason_required:
+      type: boolean
+      description: |
+        A true value here means that entering a policy violation reason is mandatory for this policy rule.
+      example: false
     action_make_unreportable:
       type: boolean
       nullable: false


### PR DESCRIPTION
### Description
Update open API specs for inclusion of new field policy_violation_reason_required for following APIS:
* ADMIN POST /admin/expense_policy_rules 
* SPENDER POST /spender/expenses/check_policies 
* SPENDER POST /spender/expense_policy_comments
* ADMIN GET /admin/expense_policy_comments
* SPENDER GET /spender/expense_policy_comments

## Clickup
https://app.clickup.com/t/86d3370yp