### PR TITLE
feat: add cost centers delete and delete_summary bulk API contracts

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -513,6 +513,107 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/403'
+  /admin/cost_centers/delete/bulk:
+    post:
+      tags:
+        - Cost Centers
+      summary: Deletes cost centers
+      description: |
+        Deletes unused cost centers. If any of the cost center in input is used in other resources then validation error is raised.
+      operationId: cost_centers_delete_bulk_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/cost_center_in_only_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    nullable: true
+                    example: |
+                      Can not delete cost center(s) used in other resources like expense, expense policy, expense rules, budgets, dependent fields.
+                  data:
+                    type: object
+                    example: null
+                  error:
+                    type: string
+                    example: InvalidUsage
+        '401':
+          description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/403'
+  /admin/cost_centers/delete_summary/bulk:
+    post:
+      tags:
+        - Cost Centers
+      summary: Create delete summary for cost centers
+      description: |
+        Delete summary tells that how many cost centers could be deleted from given cost centers, it also
+        returns cost centers that could be deleted.
+      operationId: cost_centers_delete_summary_bulk_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+                - data
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/cost_center_in_only_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/cost_center_delete_summary_out'
+        '401':
+          description: Unauthorised request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/403'
   /admin/categories:
     get:
       tags:
@@ -15211,6 +15312,33 @@ components:
                   - _While creating cost_centers, if both `restricted_spender_user_ids` and `restricted_spender_user_group` keys are not set, restrictions defaults to `"restricted_spender_user_group": {"with_no_cost_center_restrictions": "true"}`_
                   - _While updating cost_centers, if both `restricted_spender_user_ids` and `restricted_spender_user_group` keys are not set, restrictions remains unchanged._
               example: true
+    cost_center_in_only_id:
+      type: object
+      required:
+        - id
+      additionalProperties: false
+      properties:
+        id:
+          $ref: '#/components/schemas/id_integer'
+    cost_center_delete_summary_out:
+      type: object
+      additionalProperties: false
+      properties:
+        data:
+          type: object
+          properties:
+            delete_count:
+              type: integer
+              description: Count of cost centers that could be deleted from input cost centers.
+              example: 2
+            cost_centers:
+              type: array
+              description: Cost centers that could be deleted.
+              example:
+                - id: 1234
+                - id: 4567
+              items:
+                $ref: '#/components/schemas/cost_center_in_only_id'
     admin_approver_category_out:
       type: object
       additionalProperties: false

--- a/src/admin/openapi.yaml
+++ b/src/admin/openapi.yaml
@@ -155,6 +155,10 @@ paths:
     $ref: paths/admin@cost_centers.yaml
   /admin/cost_centers/bulk:
     $ref: paths/admin@cost_centers@bulk.yaml
+  /admin/cost_centers/delete/bulk:
+    $ref: paths/admin@cost_centers@delete@bulk.yaml
+  /admin/cost_centers/delete_summary/bulk:
+    $ref: paths/admin@cost_centers@delete_summary@bulk.yaml
   /admin/categories:
     $ref: paths/admin@categories.yaml
   /admin/categories/bulk:

--- a/src/admin/paths/admin@cost_centers@delete@bulk.yaml
+++ b/src/admin/paths/admin@cost_centers@delete@bulk.yaml
@@ -1,0 +1,58 @@
+post:
+  tags:
+    - Cost Centers
+  summary: Deletes cost centers
+  description: |
+    Deletes unused cost centers. If any of the cost center in input is used in other resources then validation error is raised.
+  operationId: cost_centers_delete_bulk_post
+  requestBody:
+    required: True
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: False
+          required:
+            - data
+          properties:
+            data:
+              type: array
+              items: 
+                $ref: '../../components/schemas/cost_center.yaml#/cost_center_in_only_id'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+    '401':
+      description: Unauthorised request
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/401.yaml"
+    '403':
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/403.yaml"
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                nullable: true
+                example: |
+                  Can not delete cost center(s) used in other resources like expense, expense policy, expense rules, budgets, dependent fields.
+              data:
+                type: object
+                example: null
+              error:
+                type: string
+                example: InvalidUsage

--- a/src/admin/paths/admin@cost_centers@delete_summary@bulk.yaml
+++ b/src/admin/paths/admin@cost_centers@delete_summary@bulk.yaml
@@ -1,0 +1,41 @@
+post:
+  tags:
+    - Cost Centers
+  summary: Create delete summary for cost centers
+  description: |
+    Delete summary tells that how many cost centers could be deleted from given cost centers, it also
+    returns cost centers that could be deleted.
+  operationId: cost_centers_delete_summary_bulk_post
+  requestBody:
+    required: True
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: False
+          required:
+            - data
+          properties:
+            data:
+              type: array
+              items: 
+                $ref: '../../components/schemas/cost_center.yaml#/cost_center_in_only_id'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../../components/schemas/cost_center.yaml#/cost_center_delete_summary_out'
+    '401':
+      description: Unauthorised request
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/401.yaml"
+    '403':
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/403.yaml"

--- a/src/components/schemas/cost_center.yaml
+++ b/src/components/schemas/cost_center.yaml
@@ -148,3 +148,32 @@ approver_cost_center_out:
       $ref: ./fields.yaml#/updated_at
     restricted_spender_user_ids:
       $ref: ./fields.yaml#/restricted_spender_user_ids
+
+cost_center_in_only_id:
+  type: object
+  required:
+    - id
+  additionalProperties: False
+  properties:
+    id:
+      $ref: './fields.yaml#/id_integer'
+
+cost_center_delete_summary_out:
+  type: object
+  additionalProperties: False
+  properties:
+    data:
+      type: object
+      properties:
+        delete_count:
+          type: integer
+          description: Count of cost centers that could be deleted from input cost centers.
+          example: 2
+        cost_centers:
+          type: array
+          description: Cost centers that could be deleted.
+          example:
+            - id: 1234
+            - id: 4567
+          items:
+            $ref: './cost_center.yaml#/cost_center_in_only_id'


### PR DESCRIPTION
Adds OpenAPI 3.0 contracts for:
- POST /admin/cost_centers/delete_summary/bulk
- POST /admin/cost_centers/delete/bulk

Mirrors the existing Projects delete family. Adds cost_center_in_only_id and cost_center_delete_summary_out schemas, registers both paths in src/admin/openapi.yaml, and regenerates reference/admin.yaml via @redocly/cli@2.19.0 (matching CI's bundler workflow).

## Clickup
https://app.clickup.com/t/1864988/86d3jc3xe