### PR TITLE
chore: add Platform API contract review skill

### DIFF
--- a/.codex/skills/review-platform-api-contract/SKILL.md
+++ b/.codex/skills/review-platform-api-contract/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: review-platform-api-contract
+description: Review Fyle Platform API pull requests and OpenAPI contract changes across fyle-platform-api, fyle-platform-docs source and generated references, fyle-platform-types generated TypeScript, and external or internal consumers. Use for PR review, runtime-versus-documentation comparison, backward-compatibility analysis, requiredness, nullability, enums, response shapes, OpenAPI 3.0 semantics, generated SDK impact, version classification, or evidence-backed GitHub review comments.
+---
+
+# Review Platform API Contracts
+
+Review the entire runtime-to-consumer contract chain. Treat repository evidence as authoritative, distinguish request validation from response serialization, and return proposed comments by default.
+
+## Load the references
+
+Read [references/contract-chain.md](references/contract-chain.md) for every review. Read [references/review-examples.md](references/review-examples.md) when the change involves requiredness, nullability, enums, generated types, or ambiguous runtime behavior. Rebuild conclusions from current code; use the examples as reasoning patterns, not canned findings.
+
+## 1. Establish immutable review inputs
+
+1. Locate `fyle-platform-api`, `fyle-platform-docs`, and `fyle-platform-types`, normally as sibling repositories. Search nearby directories or ask for a clone/path when one is missing; do not silently omit a link in the chain.
+2. Read each repository's `AGENTS.md` and relevant local instructions before acting.
+3. Run `git status --short --branch` in every repository. Preserve dirty worktrees and all user changes. Do not refresh, switch, generate into, or install dependencies in a dirty sibling.
+4. Resolve each default branch from `refs/remotes/origin/HEAD`; do not assume all repositories use `main`. Fetch or pull only clean worktrees. Prefer remote API evidence or a temporary worktree when refresh is unsafe.
+5. Fetch the PR metadata, base and head commits, changed files, checks, reviews, conversations, and inline comments. Record exact docs, API, and types commits used. Avoid repeating an existing finding.
+6. Keep the review read-only. Never post a comment, submit a review, approve, or request changes without explicit user authorization for that publication action.
+
+If current remote state is unavailable, state which local refs and timestamps were used and mark conclusions that may be stale.
+
+## 2. Separate source from generated output
+
+Treat `fyle-platform-docs/src/**` as the review source and `reference/*.yaml` as generated bundles.
+
+1. Map each changed reference fragment back to its `src/**` schema or path.
+2. Comment on the exact changed source line. Do not duplicate the same finding on a generated reference file.
+3. Read the affected root document's `openapi` version.
+4. Run the repository's current lint and bundle commands for each affected role when feasible.
+5. Compare regenerated output with the PR's `reference/*.yaml`. Report missing, stale, or unrelated generated changes separately.
+
+## 3. Prove request behavior
+
+Trace each changed request property from the endpoint to the loaded Marshmallow schema and action:
+
+- Inspect `required`, `allow_none`, `load_only`, defaults, missing-value behavior, validators, and unknown-field handling.
+- Inspect `post_load` conversion and action validation.
+- Inspect validation-error fixtures and successful request tests.
+- Distinguish omission from an explicit `null`.
+
+Do not infer runtime request behavior from an OpenAPI diff alone.
+
+## 4. Prove response behavior
+
+Trace each changed response property through the handler and the exact schema used for dumping. Do not treat Marshmallow `required=True` or `required=False` as response-presence evidence by itself.
+
+Inspect, as applicable:
+
+- `dump_only` fields, serialization hooks, computed fields, and the object passed to `dump`.
+- SQLAlchemy models and current database constraints.
+- The current canonical SQL view and every later migration that touches the table or view.
+- Join types that can introduce, exclude, or preserve nulls.
+- GET, POST, bulk, and action response fixtures or expected-output files.
+
+Apply these contract meanings precisely:
+
+- Marshmallow `required=False` generally permits omission while loading a request.
+- OpenAPI object-level `required` means the response key is present.
+- OpenAPI `nullable: true` means the present key may contain `null`.
+- Optional/missing and present-with-null are different contracts.
+
+When request and response shapes differ, require separate input and output schemas instead of weakening a response to mirror request optionality.
+
+## 5. Verify enums and OpenAPI semantics
+
+For an enum change:
+
+1. Compare the documented values with the current Python enum and schema validation.
+2. Inspect the database column or constraint and stored-value representation.
+3. Search migrations, fixtures, and git history for removed values and legacy support.
+4. Distinguish a falsely documented value from a historically supported or persisted value.
+5. Explain both runtime compatibility and generated TypeScript source compatibility.
+
+For OpenAPI 3.0.x, treat a Reference Object as non-extensible: schema keywords placed beside `$ref` are ignored by conforming tooling. Use `allOf` when a referenced schema genuinely needs extension. First prove the runtime contract; making `nullable` effective with `allOf` can still document the wrong behavior.
+
+## 6. Evaluate generated types and consumers
+
+Use `fyle-platform-types` as the downstream SDK representation.
+
+1. Confirm that `specs/*.yaml` sync from `fyle-platform-docs/reference/*.yaml` and inspect `openapi-ts.config.ts`, sync scripts, version-classification scripts, and CI.
+2. Use the Node and pnpm versions declared by that repository.
+3. Preserve its worktree. Compare in a temporary worktree or with temporary copies of old and proposed specs.
+4. Run the relevant existing commands when feasible: `pnpm test`, `pnpm run build`, and `pnpm run version:check`.
+5. Compare generated TypeScript before and after. Quote only representative types or signatures; do not dump the generated tree.
+6. Inspect dispatched consumer repositories when they are identifiable. Search for removed enum members, newly required arguments, optional response properties, and new null checks.
+
+Classify every impact independently:
+
+- Runtime API breaking change.
+- Request-validation correction.
+- Response-contract change.
+- Generated SDK compile/source break.
+- Documentation-only change.
+- Non-breaking contract expansion.
+
+State uncertainty when repository evidence cannot prove production legacy data or every consumer.
+
+## 7. Return actionable findings
+
+Order findings by severity. For each finding, provide:
+
+1. Category and exact `src/**` line.
+2. Concrete contract problem.
+3. Runtime and customer or SDK impact.
+4. Concise evidence from the implementation, database/view, fixtures, and generated types.
+5. A clear requested change.
+6. A proposed inline comment when useful.
+
+Attach proposed comments to source lines, not generated references. Link relevant API or types files. When the user requests latest-default-branch links, link that branch and separately record the verified commit for reproducibility. Use a small before/after example only when it clarifies the contract.
+
+Avoid vague claims such as “this may break something.” If evidence is incomplete, name the missing evidence and narrow the claim.
+
+Finish with the verified commits, commands run, checks not run, assumptions, and publication status. Return proposed comments to the user unless the user explicitly authorizes posting them.

--- a/.codex/skills/review-platform-api-contract/agents/openai.yaml
+++ b/.codex/skills/review-platform-api-contract/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Platform API Contract"
+  short_description: "Review API changes across docs, runtime, and types"
+  default_prompt: "Use $review-platform-api-contract to review this Platform API contract PR and propose evidence-backed comments."

--- a/.codex/skills/review-platform-api-contract/references/contract-chain.md
+++ b/.codex/skills/review-platform-api-contract/references/contract-chain.md
@@ -1,0 +1,165 @@
+# Platform API contract chain
+
+Use this map to find evidence and execute the current repository workflow. Re-verify commands, versions, and default branches because they can change.
+
+## Contents
+
+- [Verified repository map](#verified-repository-map)
+- [Establish PR and repository state](#establish-pr-and-repository-state)
+- [Docs source and bundles](#docs-source-and-bundles)
+- [Runtime evidence map](#runtime-evidence-map)
+- [OpenAPI 3.0 contract rules](#openapi-30-contract-rules)
+- [Types sync and classification](#types-sync-and-classification)
+- [Review comment template](#review-comment-template)
+
+## Verified repository map
+
+Verified on 2026-07-10 from these local default-branch commits:
+
+| Repository | Default branch | Verified commit | Contract role |
+| --- | --- | --- | --- |
+| `fyle-platform-api` | `master` | `1c9a1fdea2c864abfe2631019ed5709a7c0cd4cc` | Runtime handlers, validation, models, views, migrations, and fixtures |
+| `fyle-platform-docs` | `main` | `91ca9356227a0329676a5221eb4b4bae46e2292a` | Modular OpenAPI source and bundled references |
+| `fyle-platform-types` | `master` | `fd490492bf19ecdb67ed93aa9c5ca5bd76c63b1b` | Synced specs, generated TypeScript, and version classification |
+
+Resolve the branch again with `git symbolic-ref --short refs/remotes/origin/HEAD`. Record both the branch and commit used by the review.
+
+The flow is:
+
+```text
+fyle-platform-api runtime evidence
+  -> manually maintained fyle-platform-docs/src
+  -> Redocly bundles in fyle-platform-docs/reference
+  -> fyle-platform-types/specs sync
+  -> @hey-api/openapi-ts output and @fylein/types
+  -> configured internal consumers and external API/SDK users
+```
+
+The API does not generate the docs automatically. A docs-only change can leave runtime behavior unchanged while changing generated SDK types.
+
+## Establish PR and repository state
+
+Use GitHub tooling to collect the PR base/head SHAs, changed files, check rollup, reviews, issue comments, and inline review comments. Include pagination when calling the API directly. Compare the proposed finding with existing conversations before drafting it.
+
+Run these safe local checks in all three repositories:
+
+```bash
+git status --short --branch
+git symbolic-ref --short refs/remotes/origin/HEAD
+git log -1 --format='%H %cI %s'
+```
+
+Do not refresh a dirty repository. If a sibling is missing:
+
+1. Search the parent and configured workspace roots by repository name.
+2. Ask for the existing clone path before creating another clone.
+3. If cloning is authorized, clone beside the other repositories and record its default branch and commit.
+4. If evidence remains unavailable, complete only the supported parts and label the gap.
+
+## Docs source and bundles
+
+`src/<role>/openapi.yaml` declares the document version, tags, security, and path references. Endpoint definitions live in `src/<role>/paths/`; shared schemas live in `src/components/schemas/`. Filenames use `@` for URL separators.
+
+`reference/<role>.yaml` is generated. The bundler workflow currently installs `@redocly/cli@2.19.0` on Node 22 and runs this pattern:
+
+```bash
+openapi lint src/<role>/openapi.yaml
+openapi bundle -o reference/<role>.yaml src/<role>/openapi.yaml
+```
+
+The workflow bundles `authorization`, `spender`, `approver`, `common`, `admin`, `hod`, `hop`, `accountant`, `super_admin`, `owner`, and `manager`. Inspect `.github/workflows/bundler.yml` and `README.md` rather than assuming the list remains current.
+
+Review `src/**` first. Use the bundled diff to verify generation, resolve downstream type input, and spot stale output. Never place duplicate review comments on `reference/*.yaml` when the source line is available.
+
+## Runtime evidence map
+
+Start from the route and follow the actual load or dump path.
+
+For request behavior, inspect:
+
+- `api/<resource>/<role>.py` or the relevant blueprint and view.
+- `api/<resource>/schema.py` and inherited `core/schema/**` fields.
+- `required`, `allow_none`, `load_only`, defaults, missing handling, validators, and `post_load`.
+- The action class and model validation.
+- `api/tests/**/input.yaml`, validation-error expected output, and successful tests.
+
+For response behavior, inspect:
+
+- The handler's exact `get_schema` or explicit `Schema().dump(...)` call.
+- `dump_only` overrides, serialization hooks, computed values, and inheritance.
+- `db/models/**` column definitions.
+- `db-migrations/views/**` as the canonical current view.
+- The original table migration and every later migration or view rewrite touching the field.
+- Join direction and nullability of joined columns.
+- `api/tests/**/expected_output.yaml` for each relevant endpoint/action.
+
+Git history helps distinguish current truth from an outdated migration or formerly supported value:
+
+```bash
+git log --all -- <path>
+git log -p -G '<field-or-enum>' --all -- <relevant-paths>
+```
+
+Do not use an old table definition alone when a later migration added constraints. Do not use Marshmallow load semantics alone to infer a dumped response key.
+
+## OpenAPI 3.0 contract rules
+
+Read the root document's version before applying version-specific rules. The current role documents use OpenAPI 3.0.3.
+
+For 3.0.x:
+
+- A Reference Object contains `$ref`; sibling schema keywords do not extend the target for conforming tooling.
+- Wrap a reference in `allOf` to apply schema keywords, for example:
+
+```yaml
+id:
+  allOf:
+    - $ref: ./fields.yaml#/id_string
+  nullable: true
+```
+
+- Do not make this rewrite until runtime evidence proves `null` is a valid value.
+- Object-level `required` controls key presence. `nullable` controls whether a present value may be `null`.
+
+## Types sync and classification
+
+`fyle-platform-types/scripts/sync-specs.sh` copies these docs bundles into `specs/` in local mode and fetches them from the docs `main` branch in remote mode. It currently syncs 11 roles.
+
+`openapi-ts.config.ts` reads `specs/*.yaml` and generates per-role TypeScript with `@hey-api/openapi-ts`. The current repository declares Node `24.12.0` and pnpm `10.33.0`; take the exact values from `package.json` and the package-manager files at review time.
+
+Relevant commands are:
+
+```bash
+pnpm test
+pnpm run build
+pnpm run version:check
+```
+
+Do not run local `build` in the user's types worktree during a PR comparison because its sync step copies the current sibling docs bundles. Instead, use a temporary types worktree or temporary old/new spec directories, point `OLD_SPECS_DIR` and `NEW_SPECS_DIR` at them, and preserve the original worktree.
+
+The current version classifier applies the highest result:
+
+- `major`: `oasdiff breaking` reports a breaking OpenAPI change or a role disappears.
+- `minor`: structural generated TypeScript changes without a breaking diff, or a role is added.
+- `patch`: only generated comments/documentation change.
+- `none`: no generated or documentation change.
+
+Inspect `scripts/determine-version-bump.js`, its core module and tests, `.github/workflows/sync-spec-and-validate.yml`, and `openapi-ts.config.ts`. The workflow builds generated types after classification and can dispatch a `types-updated` event to repositories configured in `TYPES_CONSUMER_REPOS`; the repository does not enumerate those consumers in source.
+
+When evaluating a PR, copy the base bundles and proposed bundles into separate temporary spec directories. Compare representative generated aliases and operation inputs. A version result does not replace the semantic review: a falsely documented enum correction may be runtime-safe while still breaking source code compiled against generated types.
+
+## Review comment template
+
+Use this shape, omitting sections that add no value:
+
+```markdown
+This makes `<specific generated/runtime contract>` even though `<verified runtime fact>`.
+
+- Runtime: `<handler/schema/model/view/fixture evidence>`
+- SDK: `<representative before/after type or call signature>`
+- Verified at: `<implementation and types commit>`
+
+Please `<concrete requested change>`.
+```
+
+Attach the comment to the exact changed `src/**` line. Link default-branch files when requested, but retain verified commit SHAs in the review summary.

--- a/.codex/skills/review-platform-api-contract/references/review-examples.md
+++ b/.codex/skills/review-platform-api-contract/references/review-examples.md
@@ -1,0 +1,161 @@
+# Contract reasoning examples
+
+These examples were rebuilt from repository code and fixtures rather than existing PR comments. Re-verify them against the current branches before applying the conclusions to a new review.
+
+The examples were checked on 2026-07-10 using docs base `91ca9356227a0329676a5221eb4b4bae46e2292a`, docs PR head `dbcba50944f4c55915763eaf4f1f0b0098b06f73` (source change `5880155519465a2b02c1dbd3e12bc7b850fcca66`), API `1c9a1fdea2c864abfe2631019ed5709a7c0cd4cc`, and types `fd490492bf19ecdb67ed93aa9c5ca5bd76c63b1b`.
+
+## Contents
+
+- [A. Request optionality is not response presence](#a-request-optionality-is-not-response-presence)
+- [B. Effective nullability can still be wrong](#b-effective-nullability-can-still-be-wrong)
+- [C. A runtime correction can break generated source](#c-a-runtime-correction-can-break-generated-source)
+
+## A. Request optionality is not response presence
+
+The level API demonstrates why one schema's Marshmallow load flags cannot define both sides of an HTTP contract.
+
+Evidence:
+
+- `fyle-platform-api/api/levels/schema.py` declares `id`, `band`, `code`, and `description` with `required=False`; `band`, `code`, and `description` allow `None`.
+- `fyle-platform-api/api/levels/admin.py` uses that schema for both POST loading and GET dumping.
+- `api/tests/admin/levels/002_test_post_insert/input.yaml` sends only `name` and `is_enabled`.
+- The POST expected output and GET expected output contain `id`, `band`, `code`, and `description`; nullable values are present as `null`.
+
+A valid request is therefore:
+
+```json
+{
+  "name": "level 1",
+  "is_enabled": true
+}
+```
+
+The observed POST response is shaped like:
+
+```json
+{
+  "id": "lvlf2yiY7usuX",
+  "name": "level 1",
+  "band": null,
+  "code": null,
+  "description": null,
+  "is_enabled": true
+}
+```
+
+Removing those properties from the output schema's object-level `required` array turns guaranteed response keys into optional generated properties. The representative difference is:
+
+```ts
+// Response contract supported by fixtures
+type Level = {
+  id: string;
+  band: string | null;
+};
+
+// Contract produced when response requiredness mirrors request loading
+type Level = {
+  id?: string;
+  band?: string | null;
+};
+```
+
+General lesson: model request omission in an input schema and response presence in an output schema. A nullable response field can still be required to appear.
+
+## B. Effective nullability can still be wrong
+
+The spender personal-card `id` demonstrates the two separate questions in a nullability review: does the OpenAPI syntax apply, and can runtime return null?
+
+The reviewed OpenAPI 3.0.3 change used:
+
+```yaml
+id:
+  $ref: ./fields.yaml#/id_string
+  nullable: true
+```
+
+In OpenAPI 3.0, `nullable` beside `$ref` does not extend the referenced Schema Object. Conforming tools may ignore it. This form makes the intent effective:
+
+```yaml
+id:
+  allOf:
+    - $ref: ./fields.yaml#/id_string
+  nullable: true
+```
+
+That syntactic repair would still misrepresent the verified runtime:
+
+- `api/personal_cards/spender.py` handles GET with `PersonalCardROVAPISchema` and explicitly dumps created cards with the same ROV API schema.
+- `core/schema/personal_cards.py` defines the ROV `id` with `allow_none=False`.
+- `db/models/personal_cards.py` maps `PersonalCard.id` and `PersonalCardROV.id` as primary keys.
+- The original `platform_schema.personal_cards` migration defines `id` as a primary key, hence non-null.
+- The current canonical `db-migrations/views/platform_schema/personal_cards_rov.sql` selects `pspc.id` through an inner join; it does not synthesize a nullable identifier.
+- The later account-type migration changes only `account_type`; later RLS migrations change access policy, not ID nullability.
+- Personal-card GET expected outputs contain string IDs.
+
+The supported runtime shape is:
+
+```json
+{
+  "id": "bacctW5DfRdoSW"
+}
+```
+
+It is not:
+
+```json
+{
+  "id": null
+}
+```
+
+If the output object also omits `id` from object-level `required`, effective nullability can generate a type such as:
+
+```ts
+type PersonalCard = {
+  id?: string | null;
+};
+```
+
+General lesson: first prove that runtime can return `null`, then encode nullability using syntax supported by the affected OpenAPI version. Do not “fix” ignored syntax into an effective but false contract.
+
+## C. A runtime correction can break generated source
+
+The reviewed accounting-export-lineitem change corrects the documented `object_type` enum to the current API implementation.
+
+Runtime evidence:
+
+- `db/models/accounting_export_lineitems.py` defines `AccountExportLineitemObjectType` as `EXPENSE`, `REPORT`, `SETTLEMENT`, `REIMBURSEMENT`, `ADVANCE_REQUEST`, and `CCC_EXPENSE`.
+- `api/accounting_export_lineitems/schema.py` validates request values with `EnumField(AccountExportLineitemObjectType)`.
+- The canonical database snapshot stores `object_type` as a non-null string, so repository evidence does not rule out unknown legacy production strings by constraint alone.
+- Migrations, function tests, and fixtures use current values such as `ADVANCE_REQUEST`, `EXPENSE`, `REPORT`, `REIMBURSEMENT`, and `CCC_EXPENSE`.
+- Git history shows the Python enum with the same six values since the model entered its current location in 2022.
+
+The docs change removes falsely documented response values such as `ADVANCE`, `BALANCE_TRANSFER`, and `REFUND`, and adds `CCC_EXPENSE`. Runtime is unchanged, but a representative generated union changes:
+
+```ts
+// Before
+type ObjectType =
+  | 'ADVANCE_REQUEST'
+  | 'ADVANCE'
+  | 'BALANCE_TRANSFER'
+  | 'REFUND'
+  | 'REIMBURSEMENT'
+  | 'REPORT'
+  | 'EXPENSE'
+  | 'SETTLEMENT';
+
+// After
+type ObjectType =
+  | 'ADVANCE_REQUEST'
+  | 'CCC_EXPENSE'
+  | 'EXPENSE'
+  | 'REIMBURSEMENT'
+  | 'REPORT'
+  | 'SETTLEMENT';
+```
+
+Consumers referencing removed generated members can stop compiling even though the server never supported those values. Consumers using exhaustive response switches must also handle the newly documented `CCC_EXPENSE` value.
+
+Under the current `fyle-platform-types` classifier, any breaking change reported by `oasdiff` yields `major`; otherwise a structural generated-type change yields at least `minor`. Run `pnpm run version:check` on isolated base and proposed specs to obtain the actual whole-PR result because direction matters for request versus response enums and other changes can raise the classification.
+
+General lesson: classify runtime behavior and generated source compatibility separately. Call a change a documentation correction only for the server; it may still require an SDK migration and consumer updates.


### PR DESCRIPTION
## Summary

Adds a repo-local Codex skill for reviewing Sage Expense Management Platform API contract changes across:

- `fyle-platform-api` runtime schemas, handlers, models, database views, migrations, and fixtures
- `fyle-platform-docs/src` source OpenAPI definitions and generated `reference` bundles
- `fyle-platform-types` synced specs, generated TypeScript, and version classification
- internal and external API/SDK consumers

The skill is read-only by default and returns proposed, evidence-backed review comments unless publishing is explicitly authorized.

## Skill structure

- `SKILL.md`: concise review workflow and publication guardrails
- `references/contract-chain.md`: verified repository relationships, commands, and evidence map
- `references/review-examples.md`: request/response requiredness, OpenAPI 3.0 nullability, and generated SDK compatibility examples
- `agents/openai.yaml`: generated Codex UI metadata

## Validation

- Initialized and generated metadata with the official `skill-creator` tooling.
- `quick_validate.py`: `Skill is valid!`
- Confirmed only `name` and `description` are present in skill frontmatter.
- Confirmed all referenced files exist, no TODOs/placeholders remain, and `SKILL.md` is under 500 lines.
- Whitespace and staged-diff checks passed.
- Independently forward-tested against `fylein/fyle-platform-docs#806` in read-only mode.
- The forward-test identified request-versus-response requiredness, OpenAPI 3.0 `$ref` nullability, personal-card runtime guarantees, generated enum/source compatibility, and duplicate-comment avoidance.
- Isolated generated-type validation passed 9 tests with 4 intentional skips.
- No GitHub review comments were posted during validation.

## ClickUp

Placeholder dummy link requested for this PR: https://app.clickup.com/dummy
