### PR TITLE
fix: correct mileage rate POST request schema

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -16467,10 +16467,12 @@ components:
         rate:
           type: number
           example: 10
-          nullable: true
+          minimum: 0
+          exclusiveMinimum: true
           description: Amount (in Home currency) per unit.
         slab_rates:
           type: array
+          maxItems: 1
           items:
             type: object
             required:
@@ -16479,10 +16481,8 @@ components:
             properties:
               rate:
                 type: number
-                nullable: true
               limit:
                 type: number
-                nullable: true
         is_enabled:
           $ref: '#/components/schemas/is_enabled'
         code:

--- a/src/components/schemas/mileage_rate.yaml
+++ b/src/components/schemas/mileage_rate.yaml
@@ -99,10 +99,12 @@ mileage_rate_in:
     rate:
       type: number
       example: 10.0
-      nullable: true
+      minimum: 0
+      exclusiveMinimum: true
       description: Amount (in Home currency) per unit.
     slab_rates:
       type: array
+      maxItems: 1
       items:
         type: object
         required:
@@ -111,10 +113,8 @@ mileage_rate_in:
         properties:
           rate:
             type: number
-            nullable: true
           limit:
             type: number
-            nullable: true
     is_enabled:
       $ref: ./fields.yaml#/is_enabled
     code:


### PR DESCRIPTION
### Description

Corrects the existing POST /admin/mileage_rates OpenAPI request schema to match current API behavior:

- Documents rate as non-null and strictly greater than zero.
- Keeps slab_rates optional and limits it to zero or one item.
- Documents nested slab rate and limit values as required and non-null.
- Regenerates reference/admin.yaml using the CI-pinned Redocly CLI version.

This is a documentation-only correction and does not change API runtime behavior or response shapes.

## Clickup

https://app.clickup.com