### PR TITLE
feat: Added information for support of expense_merchants and expense_merchants_op…

### DIFF
--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -29056,7 +29056,6 @@ components:
       enum:
         - CONTAINS_ANY_FROM_LIST
         - CONTAINS_NONE_FROM_LIST
-        - null
       description: |
         Value signifying the operator for matching values from a list field.
       example: CONTAINS_ANY_FROM_LIST

--- a/reference/admin.yaml
+++ b/reference/admin.yaml
@@ -29050,6 +29050,16 @@ components:
           - COMPANY_ACCOUNT
           - null
       example: PERSONAL_CASH_ACCOUNT
+    contains_from_list_operator:
+      nullable: true
+      type: string
+      enum:
+        - CONTAINS_ANY_FROM_LIST
+        - CONTAINS_NONE_FROM_LIST
+        - null
+      description: |
+        Value signifying the operator for matching values from a list field.
+      example: CONTAINS_ANY_FROM_LIST
     vehicle_type:
       type: string
       enum:
@@ -29292,6 +29302,22 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/contains_operator'
+        expense_merchants:
+          nullable: true
+          type: array
+          items:
+            type: string
+          description: |
+            List of merchant names considered by this policy rule.
+          example:
+            - Uber
+            - Amazon
+        expense_merchants_op:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/contains_from_list_operator'
+          description: |
+            Operator to apply on `expense_merchants`.
         expense_without_ccc_match_allowed:
           type: boolean
           description: |
@@ -29542,6 +29568,8 @@ components:
             - expense_amount_max
             - expense_payment_modes
             - expense_payment_modes_op
+            - expense_merchants
+            - expense_merchants_op
             - expense_without_ccc_match_allowed
             - employee_department_ids
             - employee_department_ids_op
@@ -29745,6 +29773,23 @@ components:
             - $ref: '#/components/schemas/contains_operator'
           description: |
             _Note: This field is mandatory if the field `expense_payment_modes` is present in the request body._
+        expense_merchants:
+          type: array
+          items:
+            type: string
+          description: |
+            List of merchant names to be checked against expense merchant for applying this policy rule. <br>
+            _Note: You need to use field `expense_merchants_op` along with this field._ <br>
+            _Note: This field is allowed only when `expense_without_receipt_allowed` is false._
+          example:
+            - Uber
+            - Amazon
+        expense_merchants_op:
+          allOf:
+            - $ref: '#/components/schemas/contains_from_list_operator'
+          description: |
+            _Note: This field is mandatory if the field `expense_merchants` is present in the request body._ <br>
+            _Note: This field is allowed only when `expense_without_receipt_allowed` is false._
         expense_without_ccc_match_allowed:
           type: boolean
           description: |

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -16199,7 +16199,6 @@ components:
       enum:
         - CONTAINS_ANY_FROM_LIST
         - CONTAINS_NONE_FROM_LIST
-        - null
       description: |
         Value signifying the operator for matching values from a list field.
       example: CONTAINS_ANY_FROM_LIST

--- a/reference/spender.yaml
+++ b/reference/spender.yaml
@@ -16193,6 +16193,16 @@ components:
           - COMPANY_ACCOUNT
           - null
       example: PERSONAL_CASH_ACCOUNT
+    contains_from_list_operator:
+      nullable: true
+      type: string
+      enum:
+        - CONTAINS_ANY_FROM_LIST
+        - CONTAINS_NONE_FROM_LIST
+        - null
+      description: |
+        Value signifying the operator for matching values from a list field.
+      example: CONTAINS_ANY_FROM_LIST
     vehicle_type:
       type: string
       enum:
@@ -16435,6 +16445,22 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/contains_operator'
+        expense_merchants:
+          nullable: true
+          type: array
+          items:
+            type: string
+          description: |
+            List of merchant names considered by this policy rule.
+          example:
+            - Uber
+            - Amazon
+        expense_merchants_op:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/contains_from_list_operator'
+          description: |
+            Operator to apply on `expense_merchants`.
         expense_without_ccc_match_allowed:
           type: boolean
           description: |

--- a/src/components/schemas/expense_policies.yaml
+++ b/src/components/schemas/expense_policies.yaml
@@ -35,6 +35,8 @@ expense_policy_in:
         - expense_amount_max
         - expense_payment_modes
         - expense_payment_modes_op
+        - expense_merchants
+        - expense_merchants_op
         - expense_without_ccc_match_allowed
         - employee_department_ids
         - employee_department_ids_op
@@ -232,6 +234,21 @@ expense_policy_in:
         - $ref: ./fields.yaml#/contains_operator
       description: |
           _Note: This field is mandatory if the field `expense_payment_modes` is present in the request body._
+    expense_merchants:
+      type: array
+      items:
+        type: string
+      description: |
+        List of merchant names to be checked against expense merchant for applying this policy rule. <br>
+        _Note: You need to use field `expense_merchants_op` along with this field._ <br>
+        _Note: This field is allowed only when `expense_without_receipt_allowed` is false._
+      example: ['Uber', 'Amazon']
+    expense_merchants_op:
+      allOf:
+        - $ref: ./fields.yaml#/contains_from_list_operator
+      description: |
+          _Note: This field is mandatory if the field `expense_merchants` is present in the request body._ <br>
+          _Note: This field is allowed only when `expense_without_receipt_allowed` is false._
     expense_without_ccc_match_allowed:
       type: boolean
       description: |
@@ -669,6 +686,20 @@ expense_policy_out:
       nullable: true
       allOf:
         - $ref: ./fields.yaml#/contains_operator
+    expense_merchants:
+      nullable: true
+      type: array
+      items:
+        type: string
+      description: |
+        List of merchant names considered by this policy rule.
+      example: ['Uber', 'Amazon']
+    expense_merchants_op:
+      nullable: true
+      allOf:
+        - $ref: ./fields.yaml#/contains_from_list_operator
+      description: |
+        Operator to apply on `expense_merchants`.
     expense_without_ccc_match_allowed:
       type: boolean
       description: |

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -346,6 +346,17 @@ contains_operator:
     Value signifying the operator for the field
   example: IN
 
+contains_from_list_operator:
+  nullable: true
+  type: string
+  enum:
+    - CONTAINS_ANY_FROM_LIST
+    - CONTAINS_NONE_FROM_LIST
+    - null
+  description: >
+    Value signifying the operator for matching values from a list field.
+  example: CONTAINS_ANY_FROM_LIST
+
 delegation_access_scope:
   type: array
   description: |

--- a/src/components/schemas/fields.yaml
+++ b/src/components/schemas/fields.yaml
@@ -352,7 +352,6 @@ contains_from_list_operator:
   enum:
     - CONTAINS_ANY_FROM_LIST
     - CONTAINS_NONE_FROM_LIST
-    - null
   description: >
     Value signifying the operator for matching values from a list field.
   example: CONTAINS_ANY_FROM_LIST


### PR DESCRIPTION
… for expense_without_receipt_allowed false

### Description
Update open API specs for inclusion of new field expense_merchants and expense_merchants_op for following APIS:

POST /admin/expense_policy_rules
GET /admin/expense_policy_rules
POST /admin/expense_policy_rules/enable
POST /admin/expense_policy_rules/disable
GET /spender/expense_policy_rules

## Clickup
https://app.clickup.com/t/1864988/86d3aeaea